### PR TITLE
Add Exa toolkit with Search, Find Similar, Contents, and Answer tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,6 @@ DB_CONNECTION=testing
 # Tavily API key (https://app.tavily.com)
 TAVILY_API_KEY=
 
+EXA_API_KEY=
+
 OPENAI_API_KEY=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,16 @@
 name: Tests
 
-on: ["push", "pull_request"]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "replace": {
         "shipfastlabs/toolkit-calculator": "self.version",
         "shipfastlabs/toolkit-database": "self.version",
+        "shipfastlabs/toolkit-exa": "self.version",
         "shipfastlabs/toolkit-stub": "self.version",
         "shipfastlabs/toolkit-tavily": "self.version"
     },
@@ -43,6 +44,7 @@
             "Shipfastlabs\\Toolkit\\": "src/",
             "Shipfastlabs\\Toolkit\\Calculator\\": "src/Calculator/src/",
             "Shipfastlabs\\Toolkit\\Database\\": "src/Database/src/",
+            "Shipfastlabs\\Toolkit\\Exa\\": "src/Exa/src/",
             "Shipfastlabs\\Toolkit\\Tavily\\": "src/Tavily/src/"
         }
     },
@@ -50,6 +52,7 @@
         "psr-4": {
             "Shipfastlabs\\Toolkit\\Calculator\\Tests\\": "src/Calculator/tests/",
             "Shipfastlabs\\Toolkit\\Database\\Tests\\": "src/Database/tests/",
+            "Shipfastlabs\\Toolkit\\Exa\\Tests\\": "src/Exa/tests/",
             "Shipfastlabs\\Toolkit\\Tavily\\Tests\\": "src/Tavily/tests/",
             "Shipfastlabs\\Toolkit\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/",

--- a/docs/tools/exa.md
+++ b/docs/tools/exa.md
@@ -1,0 +1,191 @@
+# Exa
+
+> Exa tools for the Laravel AI SDK - Search, Find Similar, Get Contents, and Answer
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-exa
+```
+
+## Usage
+
+Register every Exa tool at once with the `Exa` helper:
+
+```php
+use Shipfastlabs\Toolkit\Exa\Exa;
+
+$tools = Exa::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\Exa\ExaSearch;
+use Shipfastlabs\Toolkit\Exa\ExaFindSimilar;
+use Shipfastlabs\Toolkit\Exa\ExaGetContents;
+use Shipfastlabs\Toolkit\Exa\ExaAnswer;
+
+$tools = [
+    new ExaSearch,
+    new ExaFindSimilar,
+    new ExaGetContents,
+    new ExaAnswer,
+];
+```
+
+## Tools
+
+### ExaSearch
+
+Search the web with Exa's embeddings-based search engine.
+
+| Parameter         | Type    | Required | Description                                                                 |
+|-------------------|---------|----------|-----------------------------------------------------------------------------|
+| `query`           | string  | yes      | The search query to look up on the web.                                     |
+| `type`            | string  | no       | `"auto"`, `"keyword"`, `"neural"`, `"fast"`, or `"deep"`. Defaults to `"auto"`. |
+| `num_results`     | integer | no       | Number of results to return (1-25). Defaults to 10.                         |
+| `category`        | string  | no       | Focus a category, e.g. `"research paper"`, `"news"`, `"github"`, `"pdf"`.   |
+| `include_domains` | string  | no       | Comma-separated domains to restrict results to.                            |
+| `exclude_domains` | string  | no       | Comma-separated domains to exclude from results.                           |
+| `include_text`    | boolean | no       | Whether to include each result's full page text. Defaults to true.          |
+
+### ExaFindSimilar
+
+Find pages semantically similar to a given URL.
+
+| Parameter         | Type    | Required | Description                                                                 |
+|-------------------|---------|----------|-----------------------------------------------------------------------------|
+| `url`             | string  | yes      | The URL to find similar pages for.                                          |
+| `num_results`     | integer | no       | Number of similar results to return (1-25). Defaults to 10.                 |
+| `include_domains` | string  | no       | Comma-separated domains to restrict results to.                            |
+| `exclude_domains` | string  | no       | Comma-separated domains to exclude from results.                           |
+| `include_text`    | boolean | no       | Whether to include each result's full page text. Defaults to true.          |
+
+### ExaGetContents
+
+Retrieve clean, parsed contents from one or more URLs.
+
+| Parameter    | Type    | Required | Description                                                                     |
+|--------------|---------|----------|---------------------------------------------------------------------------------|
+| `urls`       | string  | yes      | A single URL or comma-separated URLs (max 20) to fetch contents from.           |
+| `text`       | boolean | no       | Whether to include the full page text. Defaults to true.                        |
+| `summary`    | boolean | no       | Whether to include an AI-generated summary of each page. Defaults to false.     |
+| `highlights` | boolean | no       | Whether to include relevant highlighted snippets. Defaults to false.            |
+| `livecrawl`  | string  | no       | `"never"`, `"fallback"`, `"always"`, or `"preferred"`. Defaults to `"fallback"`. |
+
+### ExaAnswer
+
+Get a direct, sourced answer to a question with citations.
+
+| Parameter      | Type    | Required | Description                                                              |
+|----------------|---------|----------|--------------------------------------------------------------------------|
+| `query`        | string  | yes      | The question to answer using web sources.                                |
+| `include_text` | boolean | no       | Whether to include the full text of each cited source. Defaults to false. |
+
+## Provider setup
+
+All tools read their API credentials from Laravel's `services` config and their optional defaults from the `ai` config.
+
+### 1. Add the Exa service to `config/services.php`
+
+```php
+// config/services.php
+
+return [
+
+    // ... existing services ...
+
+    'exa' => [
+        'key' => env('EXA_API_KEY'),
+    ],
+
+];
+```
+
+### 2. Add toolkit defaults to `config/ai.php`
+
+```php
+// config/ai.php
+
+return [
+
+    // ... existing laravel/ai config ...
+
+    'toolkit' => [
+        'exa' => [
+            'search' => [
+                'num_results' => (int) env('EXA_SEARCH_NUM_RESULTS', 10),
+                'type' => env('EXA_SEARCH_TYPE', 'auto'),
+                'include_text' => (bool) env('EXA_SEARCH_INCLUDE_TEXT', true),
+            ],
+            'find_similar' => [
+                'num_results' => (int) env('EXA_FIND_SIMILAR_NUM_RESULTS', 10),
+                'include_text' => (bool) env('EXA_FIND_SIMILAR_INCLUDE_TEXT', true),
+            ],
+            'contents' => [
+                'text' => (bool) env('EXA_CONTENTS_TEXT', true),
+                'livecrawl' => env('EXA_CONTENTS_LIVECRAWL', 'fallback'),
+            ],
+            'answer' => [
+                'include_text' => (bool) env('EXA_ANSWER_INCLUDE_TEXT', false),
+            ],
+        ],
+    ],
+
+];
+```
+
+### 3. Add environment variables to `.env`
+
+```dotenv
+EXA_API_KEY=your-key-here
+
+# Search defaults
+EXA_SEARCH_NUM_RESULTS=10
+EXA_SEARCH_TYPE=auto
+EXA_SEARCH_INCLUDE_TEXT=true
+
+# Find similar defaults
+EXA_FIND_SIMILAR_NUM_RESULTS=10
+EXA_FIND_SIMILAR_INCLUDE_TEXT=true
+
+# Contents defaults
+EXA_CONTENTS_TEXT=true
+EXA_CONTENTS_LIVECRAWL=fallback
+
+# Answer defaults
+EXA_ANSWER_INCLUDE_TEXT=false
+```
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `services.exa.key` | `EXA_API_KEY` | - | **Required.** Your Exa API key. |
+| `ai.toolkit.exa.search.num_results` | `EXA_SEARCH_NUM_RESULTS` | `10` | Default search results (1-25). |
+| `ai.toolkit.exa.search.type` | `EXA_SEARCH_TYPE` | `"auto"` | `"auto"`, `"keyword"`, `"neural"`, `"fast"`, or `"deep"`. |
+| `ai.toolkit.exa.search.include_text` | `EXA_SEARCH_INCLUDE_TEXT` | `true` | Include full page text in search results. |
+| `ai.toolkit.exa.find_similar.num_results` | `EXA_FIND_SIMILAR_NUM_RESULTS` | `10` | Default similar results (1-25). |
+| `ai.toolkit.exa.find_similar.include_text` | `EXA_FIND_SIMILAR_INCLUDE_TEXT` | `true` | Include full page text in similar results. |
+| `ai.toolkit.exa.contents.text` | `EXA_CONTENTS_TEXT` | `true` | Include full page text in contents. |
+| `ai.toolkit.exa.contents.livecrawl` | `EXA_CONTENTS_LIVECRAWL` | `"fallback"` | `"never"`, `"fallback"`, `"always"`, or `"preferred"`. |
+| `ai.toolkit.exa.answer.include_text` | `EXA_ANSWER_INCLUDE_TEXT` | `false` | Include full text of cited sources. |
+
+## Safety
+
+- All tools validate required inputs before calling the API.
+- Numeric parameters are clamped to their valid ranges; enums fall back to safe defaults.
+- `ExaGetContents` accepts at most 20 URLs per request.
+- API errors are caught and returned as friendly string messages.
+- Requires a valid Exa API key.
+
+## Exa API
+
+These tools use the [Exa API](https://exa.ai). Exa offers a free tier to get started.
+
+Full API reference:
+- [Search Endpoint](https://exa.ai/docs/reference/search)
+- [Find Similar Links Endpoint](https://exa.ai/docs/reference/find-similar-links)
+- [Get Contents Endpoint](https://exa.ai/docs/reference/get-contents)
+- [Answer Endpoint](https://exa.ai/docs/reference/answer)

--- a/src/Exa/README.md
+++ b/src/Exa/README.md
@@ -1,0 +1,197 @@
+# shipfastlabs/toolkit-exa
+
+[![Latest Version](https://img.shields.io/packagist/v/shipfastlabs/toolkit-exa.svg)](https://packagist.org/packages/shipfastlabs/toolkit-exa)
+[![Total Downloads](https://img.shields.io/packagist/dt/shipfastlabs/toolkit-exa.svg)](https://packagist.org/packages/shipfastlabs/toolkit-exa)
+
+> Exa tools for the Laravel AI SDK - Search, Find Similar, Get Contents, and Answer
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+<!-- AUTO-GENERATED: do not edit above this line. Run `tools/docgen.sh`. -->
+
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-exa
+```
+
+## Usage
+
+Register every Exa tool at once with the `Exa` helper:
+
+```php
+use Shipfastlabs\Toolkit\Exa\Exa;
+
+$tools = Exa::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\Exa\ExaSearch;
+use Shipfastlabs\Toolkit\Exa\ExaFindSimilar;
+use Shipfastlabs\Toolkit\Exa\ExaGetContents;
+use Shipfastlabs\Toolkit\Exa\ExaAnswer;
+
+$tools = [
+    new ExaSearch,
+    new ExaFindSimilar,
+    new ExaGetContents,
+    new ExaAnswer,
+];
+```
+
+## Tools
+
+### ExaSearch
+
+Search the web with Exa's embeddings-based search engine.
+
+| Parameter         | Type    | Required | Description                                                                 |
+|-------------------|---------|----------|-----------------------------------------------------------------------------|
+| `query`           | string  | yes      | The search query to look up on the web.                                     |
+| `type`            | string  | no       | `"auto"`, `"keyword"`, `"neural"`, `"fast"`, or `"deep"`. Defaults to `"auto"`. |
+| `num_results`     | integer | no       | Number of results to return (1-25). Defaults to 10.                         |
+| `category`        | string  | no       | Focus a category, e.g. `"research paper"`, `"news"`, `"github"`, `"pdf"`.   |
+| `include_domains` | string  | no       | Comma-separated domains to restrict results to.                            |
+| `exclude_domains` | string  | no       | Comma-separated domains to exclude from results.                           |
+| `include_text`    | boolean | no       | Whether to include each result's full page text. Defaults to true.          |
+
+### ExaFindSimilar
+
+Find pages semantically similar to a given URL.
+
+| Parameter         | Type    | Required | Description                                                                 |
+|-------------------|---------|----------|-----------------------------------------------------------------------------|
+| `url`             | string  | yes      | The URL to find similar pages for.                                          |
+| `num_results`     | integer | no       | Number of similar results to return (1-25). Defaults to 10.                 |
+| `include_domains` | string  | no       | Comma-separated domains to restrict results to.                            |
+| `exclude_domains` | string  | no       | Comma-separated domains to exclude from results.                           |
+| `include_text`    | boolean | no       | Whether to include each result's full page text. Defaults to true.          |
+
+### ExaGetContents
+
+Retrieve clean, parsed contents from one or more URLs.
+
+| Parameter    | Type    | Required | Description                                                                     |
+|--------------|---------|----------|---------------------------------------------------------------------------------|
+| `urls`       | string  | yes      | A single URL or comma-separated URLs (max 20) to fetch contents from.           |
+| `text`       | boolean | no       | Whether to include the full page text. Defaults to true.                        |
+| `summary`    | boolean | no       | Whether to include an AI-generated summary of each page. Defaults to false.     |
+| `highlights` | boolean | no       | Whether to include relevant highlighted snippets. Defaults to false.            |
+| `livecrawl`  | string  | no       | `"never"`, `"fallback"`, `"always"`, or `"preferred"`. Defaults to `"fallback"`. |
+
+### ExaAnswer
+
+Get a direct, sourced answer to a question with citations.
+
+| Parameter      | Type    | Required | Description                                                              |
+|----------------|---------|----------|--------------------------------------------------------------------------|
+| `query`        | string  | yes      | The question to answer using web sources.                                |
+| `include_text` | boolean | no       | Whether to include the full text of each cited source. Defaults to false. |
+
+## Provider setup
+
+All tools read their API credentials from Laravel's `services` config and their optional defaults from the `ai` config.
+
+### 1. Add the Exa service to `config/services.php`
+
+```php
+// config/services.php
+
+return [
+
+    // ... existing services ...
+
+    'exa' => [
+        'key' => env('EXA_API_KEY'),
+    ],
+
+];
+```
+
+### 2. Add toolkit defaults to `config/ai.php`
+
+```php
+// config/ai.php
+
+return [
+
+    // ... existing laravel/ai config ...
+
+    'toolkit' => [
+        'exa' => [
+            'search' => [
+                'num_results' => (int) env('EXA_SEARCH_NUM_RESULTS', 10),
+                'type' => env('EXA_SEARCH_TYPE', 'auto'),
+                'include_text' => (bool) env('EXA_SEARCH_INCLUDE_TEXT', true),
+            ],
+            'find_similar' => [
+                'num_results' => (int) env('EXA_FIND_SIMILAR_NUM_RESULTS', 10),
+                'include_text' => (bool) env('EXA_FIND_SIMILAR_INCLUDE_TEXT', true),
+            ],
+            'contents' => [
+                'text' => (bool) env('EXA_CONTENTS_TEXT', true),
+                'livecrawl' => env('EXA_CONTENTS_LIVECRAWL', 'fallback'),
+            ],
+            'answer' => [
+                'include_text' => (bool) env('EXA_ANSWER_INCLUDE_TEXT', false),
+            ],
+        ],
+    ],
+
+];
+```
+
+### 3. Add environment variables to `.env`
+
+```dotenv
+EXA_API_KEY=your-key-here
+
+# Search defaults
+EXA_SEARCH_NUM_RESULTS=10
+EXA_SEARCH_TYPE=auto
+EXA_SEARCH_INCLUDE_TEXT=true
+
+# Find similar defaults
+EXA_FIND_SIMILAR_NUM_RESULTS=10
+EXA_FIND_SIMILAR_INCLUDE_TEXT=true
+
+# Contents defaults
+EXA_CONTENTS_TEXT=true
+EXA_CONTENTS_LIVECRAWL=fallback
+
+# Answer defaults
+EXA_ANSWER_INCLUDE_TEXT=false
+```
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `services.exa.key` | `EXA_API_KEY` | - | **Required.** Your Exa API key. |
+| `ai.toolkit.exa.search.num_results` | `EXA_SEARCH_NUM_RESULTS` | `10` | Default search results (1-25). |
+| `ai.toolkit.exa.search.type` | `EXA_SEARCH_TYPE` | `"auto"` | `"auto"`, `"keyword"`, `"neural"`, `"fast"`, or `"deep"`. |
+| `ai.toolkit.exa.search.include_text` | `EXA_SEARCH_INCLUDE_TEXT` | `true` | Include full page text in search results. |
+| `ai.toolkit.exa.find_similar.num_results` | `EXA_FIND_SIMILAR_NUM_RESULTS` | `10` | Default similar results (1-25). |
+| `ai.toolkit.exa.find_similar.include_text` | `EXA_FIND_SIMILAR_INCLUDE_TEXT` | `true` | Include full page text in similar results. |
+| `ai.toolkit.exa.contents.text` | `EXA_CONTENTS_TEXT` | `true` | Include full page text in contents. |
+| `ai.toolkit.exa.contents.livecrawl` | `EXA_CONTENTS_LIVECRAWL` | `"fallback"` | `"never"`, `"fallback"`, `"always"`, or `"preferred"`. |
+| `ai.toolkit.exa.answer.include_text` | `EXA_ANSWER_INCLUDE_TEXT` | `false` | Include full text of cited sources. |
+
+## Safety
+
+- All tools validate required inputs before calling the API.
+- Numeric parameters are clamped to their valid ranges; enums fall back to safe defaults.
+- `ExaGetContents` accepts at most 20 URLs per request.
+- API errors are caught and returned as friendly string messages.
+- Requires a valid Exa API key.
+
+## Exa API
+
+These tools use the [Exa API](https://exa.ai). Exa offers a free tier to get started.
+
+Full API reference:
+- [Search Endpoint](https://exa.ai/docs/reference/search)
+- [Find Similar Links Endpoint](https://exa.ai/docs/reference/find-similar-links)
+- [Get Contents Endpoint](https://exa.ai/docs/reference/get-contents)
+- [Answer Endpoint](https://exa.ai/docs/reference/answer)

--- a/src/Exa/composer.json
+++ b/src/Exa/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "shipfastlabs/toolkit-exa",
+    "description": "Exa tools for the Laravel AI SDK - Search, Find Similar, Get Contents, and Answer",
+    "keywords": ["laravel", "ai", "tool", "exa", "search", "contents", "answer", "find-similar"],
+    "license": "MIT",
+    "require": {
+        "php": "^8.4.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "laravel/ai": "^0.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Exa\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Exa\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/Exa/src/Concerns/InteractsWithExa.php
+++ b/src/Exa/src/Concerns/InteractsWithExa.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Exa\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Tools\Request;
+use Throwable;
+
+trait InteractsWithExa
+{
+    private function exaApiKey(): ?string
+    {
+        $apiKey = config('services.exa.key');
+
+        return is_string($apiKey) && $apiKey !== '' ? $apiKey : null;
+    }
+
+    private function exaNotConfiguredMessage(): string
+    {
+        return 'The Exa tool is not configured. Set services.exa.key in your config/services.php file.';
+    }
+
+    private function exaClient(string $apiKey, int $timeout): PendingRequest
+    {
+        return Http::baseUrl('https://api.exa.ai')
+            ->timeout($timeout)
+            ->withHeader('x-api-key', $apiKey);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function exaRequest(string $apiKey, int $timeout, string $path, array $payload, string $label): string
+    {
+        try {
+            $response = $this->exaClient($apiKey, $timeout)->post($path, $payload);
+        } catch (Throwable $throwable) {
+            return sprintf('The Exa %s request failed: %s', $label, $throwable->getMessage());
+        }
+
+        if ($response->failed()) {
+            return sprintf(
+                'The Exa %s request failed with status %d: %s',
+                $label,
+                $response->status(),
+                $response->body()
+            );
+        }
+
+        $data = $response->json();
+
+        if (! is_array($data)) {
+            return sprintf('The Exa %s response was invalid.', $label);
+        }
+
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    private function exaNumResults(Request $request, string $configKey): int
+    {
+        if ($request->has('num_results') && $request['num_results'] !== null) {
+            return max(1, min(25, $request->integer('num_results')));
+        }
+
+        $num = config($configKey, 10);
+
+        return is_numeric($num) ? max(1, min(25, (int) $num)) : 10;
+    }
+
+    private function exaIncludeText(Request $request, string $configKey, bool $default): bool
+    {
+        if ($request->has('include_text') && $request['include_text'] !== null) {
+            return $request->boolean('include_text');
+        }
+
+        return (bool) config($configKey, $default);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseDomains(Request $request, string $key): array
+    {
+        if (! $request->has($key) || $request[$key] === null) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(trim(...), explode(',', (string) $request->string($key))),
+            static fn (string $domain): bool => $domain !== '',
+        ));
+    }
+}

--- a/src/Exa/src/Exa.php
+++ b/src/Exa/src/Exa.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Exa;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+
+class Exa
+{
+    /**
+     * @return Collection<int, Tool>
+     */
+    public static function all(): Collection
+    {
+        return new Collection([
+            new ExaSearch,
+            new ExaFindSimilar,
+            new ExaGetContents,
+            new ExaAnswer,
+        ]);
+    }
+}

--- a/src/Exa/src/ExaAnswer.php
+++ b/src/Exa/src/ExaAnswer.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Exa;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Exa\Concerns\InteractsWithExa;
+
+#[Strict]
+class ExaAnswer implements Tool
+{
+    use InteractsWithExa;
+
+    public function description(): string
+    {
+        return <<<'DESCRIPTION'
+            Get a direct, sourced answer to a question using Exa. Exa searches the web, reads the most relevant pages, and returns a concise answer together with the citations it was based on.
+            DESCRIPTION;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema
+                ->string()
+                ->description('The question to answer using web sources')
+                ->required(),
+            'include_text' => $schema
+                ->boolean()
+                ->description('Whether to include the full text of each cited source in the response (default: false)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $query = trim((string) $request->string('query'));
+
+        if ($query === '') {
+            return 'The question is empty. Provide a question to answer.';
+        }
+
+        $apiKey = $this->exaApiKey();
+
+        if ($apiKey === null) {
+            return $this->exaNotConfiguredMessage();
+        }
+
+        $payload = ['query' => $query];
+
+        if ($this->exaIncludeText($request, 'ai.toolkit.exa.answer.include_text', false)) {
+            $payload['text'] = true;
+        }
+
+        return $this->exaRequest($apiKey, 60, '/answer', $payload, 'answer');
+    }
+}

--- a/src/Exa/src/ExaFindSimilar.php
+++ b/src/Exa/src/ExaFindSimilar.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Exa;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Exa\Concerns\InteractsWithExa;
+
+#[Strict]
+class ExaFindSimilar implements Tool
+{
+    use InteractsWithExa;
+
+    public function description(): string
+    {
+        return <<<'DESCRIPTION'
+            Find web pages semantically similar to a given URL using Exa. Given a link, returns other pages with related content - ideal for discovering competitors, related research, or alternative sources.
+            DESCRIPTION;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema
+                ->string()
+                ->description('The URL to find similar pages for')
+                ->required(),
+            'num_results' => $schema
+                ->integer()
+                ->description('Number of similar results to return (1-25, default: 10)')
+                ->nullable()
+                ->required(),
+            'include_domains' => $schema
+                ->string()
+                ->description('Comma-separated list of domains to restrict results to')
+                ->nullable()
+                ->required(),
+            'exclude_domains' => $schema
+                ->string()
+                ->description('Comma-separated list of domains to exclude from results')
+                ->nullable()
+                ->required(),
+            'include_text' => $schema
+                ->boolean()
+                ->description('Whether to include the full page text of each result (default: true)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $url = trim((string) $request->string('url'));
+
+        if ($url === '') {
+            return 'The URL is empty. Provide a URL to find similar pages for.';
+        }
+
+        $apiKey = $this->exaApiKey();
+
+        if ($apiKey === null) {
+            return $this->exaNotConfiguredMessage();
+        }
+
+        $payload = [
+            'url' => $url,
+            'numResults' => $this->exaNumResults($request, 'ai.toolkit.exa.find_similar.num_results'),
+        ];
+
+        $includeDomains = $this->parseDomains($request, 'include_domains');
+
+        if ($includeDomains !== []) {
+            $payload['includeDomains'] = $includeDomains;
+        }
+
+        $excludeDomains = $this->parseDomains($request, 'exclude_domains');
+
+        if ($excludeDomains !== []) {
+            $payload['excludeDomains'] = $excludeDomains;
+        }
+
+        if ($this->exaIncludeText($request, 'ai.toolkit.exa.find_similar.include_text', true)) {
+            $payload['contents'] = ['text' => true];
+        }
+
+        return $this->exaRequest($apiKey, 30, '/findSimilar', $payload, 'find similar');
+    }
+}

--- a/src/Exa/src/ExaGetContents.php
+++ b/src/Exa/src/ExaGetContents.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Exa;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Exa\Concerns\InteractsWithExa;
+
+#[Strict]
+class ExaGetContents implements Tool
+{
+    use InteractsWithExa;
+
+    public function description(): string
+    {
+        return <<<'DESCRIPTION'
+            Retrieve clean, parsed contents from one or more URLs using Exa. Returns full page text and optionally AI-generated summaries and relevant highlights, with control over fresh (live) crawling.
+            DESCRIPTION;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'urls' => $schema
+                ->string()
+                ->description('A single URL or comma-separated list of URLs to fetch contents from')
+                ->required(),
+            'text' => $schema
+                ->boolean()
+                ->description('Get the page text content (default: true)')
+                ->nullable()
+                ->required(),
+            'summary' => $schema
+                ->boolean()
+                ->description('Get an AI-generated summary of each page (default: false)')
+                ->nullable()
+                ->required(),
+            'highlights' => $schema
+                ->boolean()
+                ->description('Get text snippets the LLM identifies as most relevant from each page (default: false)')
+                ->nullable()
+                ->required(),
+            'livecrawl' => $schema
+                ->string()
+                ->description("Livecrawl mode - 'never', 'fallback', 'always', or 'preferred' (default: 'fallback')")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $urlsInput = trim((string) $request->string('urls'));
+
+        if ($urlsInput === '') {
+            return 'The URLs are empty. Provide at least one URL to fetch contents from.';
+        }
+
+        $urls = array_values(array_filter(
+            array_map(trim(...), explode(',', $urlsInput)),
+            static fn (string $url): bool => $url !== '',
+        ));
+
+        if ($urls === []) {
+            return 'No valid URLs were provided.';
+        }
+
+        if (count($urls) > 20) {
+            return 'A maximum of 20 URLs is allowed per request.';
+        }
+
+        $apiKey = $this->exaApiKey();
+
+        if ($apiKey === null) {
+            return $this->exaNotConfiguredMessage();
+        }
+
+        $payload = ['urls' => $urls];
+
+        $text = $request->has('text') && $request['text'] !== null
+            ? $request->boolean('text')
+            : $this->defaultText();
+        $payload['text'] = $text;
+
+        if ($request->has('summary') && $request['summary'] !== null && $request->boolean('summary')) {
+            $payload['summary'] = true;
+        }
+
+        if ($request->has('highlights') && $request['highlights'] !== null && $request->boolean('highlights')) {
+            $payload['highlights'] = true;
+        }
+
+        $livecrawl = $request->has('livecrawl') && $request['livecrawl'] !== null
+            ? $this->validateLivecrawl((string) $request->string('livecrawl'))
+            : $this->defaultLivecrawl();
+        $payload['livecrawl'] = $livecrawl;
+
+        return $this->exaRequest($apiKey, 60, '/contents', $payload, 'contents');
+    }
+
+    private function defaultText(): bool
+    {
+        return (bool) config('ai.toolkit.exa.contents.text', true);
+    }
+
+    private function defaultLivecrawl(): string
+    {
+        $mode = config('ai.toolkit.exa.contents.livecrawl', 'fallback');
+
+        return $this->validateLivecrawl(is_string($mode) ? $mode : 'fallback');
+    }
+
+    private function validateLivecrawl(string $mode): string
+    {
+        return in_array($mode, ['never', 'fallback', 'always', 'preferred'], true) ? $mode : 'fallback';
+    }
+}

--- a/src/Exa/src/ExaSearch.php
+++ b/src/Exa/src/ExaSearch.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Exa;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Exa\Concerns\InteractsWithExa;
+
+#[Strict]
+class ExaSearch implements Tool
+{
+    use InteractsWithExa;
+
+    public function description(): string
+    {
+        return <<<'DESCRIPTION'
+            Search the web for code docs, current information, news, articles, and content. Use this when you need up-to-date information or facts from the internet. Performs real-time web searches and can scrape content from specific URLs.
+            DESCRIPTION;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema
+                ->string()
+                ->description("The web search query - be specific and clear about what you're looking for")
+                ->required(),
+            'type' => $schema
+                ->string()
+                ->description("Search type - 'auto' intelligently combines keyword and neural, 'keyword' is fast keyword search, 'neural' is deep semantic search, 'fast' is streamlined neural and keyword, 'deep' is comprehensive deep search with enhanced analysis (default: 'auto')")
+                ->nullable()
+                ->required(),
+            'num_results' => $schema
+                ->integer()
+                ->description('Number of results to return (1-25, default: 10)')
+                ->nullable()
+                ->required(),
+            'category' => $schema
+                ->string()
+                ->description("Category to focus the search on - one of 'company', 'research paper', 'news', 'pdf', 'github', 'personal site', 'linkedin profile', 'financial report'")
+                ->nullable()
+                ->required(),
+            'include_domains' => $schema
+                ->string()
+                ->description('Comma-separated list of domains to include (e.g., "arxiv.org,github.com")')
+                ->nullable()
+                ->required(),
+            'exclude_domains' => $schema
+                ->string()
+                ->description('Comma-separated list of domains to exclude')
+                ->nullable()
+                ->required(),
+            'include_text' => $schema
+                ->boolean()
+                ->description('Whether to retrieve the page text content for each result (default: true)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $query = trim((string) $request->string('query'));
+
+        if ($query === '') {
+            return 'The search query is empty. Provide a query to search for.';
+        }
+
+        $apiKey = $this->exaApiKey();
+
+        if ($apiKey === null) {
+            return $this->exaNotConfiguredMessage();
+        }
+
+        $payload = [
+            'query' => $query,
+            'type' => $request->has('type') && $request['type'] !== null
+                ? $this->validateType((string) $request->string('type'))
+                : $this->defaultType(),
+            'numResults' => $this->exaNumResults($request, 'ai.toolkit.exa.search.num_results'),
+        ];
+
+        if ($request->has('category') && $request['category'] !== null) {
+            $category = $this->validateCategory((string) $request->string('category'));
+
+            if ($category !== null) {
+                $payload['category'] = $category;
+            }
+        }
+
+        $includeDomains = $this->parseDomains($request, 'include_domains');
+
+        if ($includeDomains !== []) {
+            $payload['includeDomains'] = $includeDomains;
+        }
+
+        $excludeDomains = $this->parseDomains($request, 'exclude_domains');
+
+        if ($excludeDomains !== []) {
+            $payload['excludeDomains'] = $excludeDomains;
+        }
+
+        if ($this->exaIncludeText($request, 'ai.toolkit.exa.search.include_text', true)) {
+            $payload['contents'] = ['text' => true];
+        }
+
+        return $this->exaRequest($apiKey, 30, '/search', $payload, 'search');
+    }
+
+    private function defaultType(): string
+    {
+        $type = config('ai.toolkit.exa.search.type', 'auto');
+
+        return $this->validateType(is_string($type) ? $type : 'auto');
+    }
+
+    private function validateType(string $type): string
+    {
+        return in_array($type, ['auto', 'keyword', 'neural', 'fast', 'deep'], true) ? $type : 'auto';
+    }
+
+    private function validateCategory(string $category): ?string
+    {
+        $allowed = [
+            'company', 'research paper', 'news', 'pdf', 'github',
+            'personal site', 'linkedin profile', 'financial report',
+        ];
+
+        return in_array($category, $allowed, true) ? $category : null;
+    }
+}

--- a/src/Exa/tests/ExaAnswerTest.php
+++ b/src/Exa/tests/ExaAnswerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Exa\ExaAnswer;
+
+it('has a description', function (): void {
+    expect((new ExaAnswer)->description())->toContain('answer');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new ExaAnswer))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new ExaAnswer)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('query')
+        ->and($schema)->toHaveKey('include_text');
+});
+
+it('returns an error when the query is empty', function (): void {
+    $result = (new ExaAnswer)->handle(new Request(['query' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.exa.key');
+
+    $result = (new ExaAnswer)->handle(new Request(['query' => 'What is Laravel?']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('returns an answer on success', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake([
+        'https://api.exa.ai/answer' => Http::response([
+            'answer' => 'Laravel is a PHP web framework.',
+            'citations' => [
+                ['url' => 'https://laravel.com', 'title' => 'Laravel'],
+            ],
+        ]),
+    ]);
+
+    $result = (new ExaAnswer)->handle(new Request(['query' => 'What is Laravel?']));
+
+    expect($result)->toContain('Laravel is a PHP web framework.')
+        ->and($result)->toContain('https://laravel.com');
+});
+
+it('uses defaults when optional params are omitted', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('query', 'What is Laravel?')
+            ->not->toHaveKey('text');
+
+        return Http::response(['answer' => 'ok']);
+    });
+
+    (new ExaAnswer)->handle(new Request(['query' => 'What is Laravel?']));
+});
+
+it('includes text when include_text is true', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('text', true);
+
+        return Http::response(['answer' => 'ok']);
+    });
+
+    (new ExaAnswer)->handle(new Request(['query' => 'What is Laravel?', 'include_text' => true]));
+});
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake([
+        'https://api.exa.ai/answer' => Http::response('Rate limited', 429),
+    ]);
+
+    $result = (new ExaAnswer)->handle(new Request(['query' => 'What is Laravel?']));
+
+    expect($result)->toContain('failed with status 429');
+});

--- a/src/Exa/tests/ExaFindSimilarTest.php
+++ b/src/Exa/tests/ExaFindSimilarTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Exa\ExaFindSimilar;
+
+it('has a description', function (): void {
+    expect((new ExaFindSimilar)->description())->toContain('similar');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new ExaFindSimilar))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new ExaFindSimilar)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('url')
+        ->and($schema)->toHaveKey('num_results')
+        ->and($schema)->toHaveKey('include_domains')
+        ->and($schema)->toHaveKey('exclude_domains')
+        ->and($schema)->toHaveKey('include_text');
+});
+
+it('returns an error when the url is empty', function (): void {
+    $result = (new ExaFindSimilar)->handle(new Request(['url' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.exa.key');
+
+    $result = (new ExaFindSimilar)->handle(new Request(['url' => 'https://laravel.com']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('returns similar results on success', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake([
+        'https://api.exa.ai/findSimilar' => Http::response([
+            'results' => [
+                ['title' => 'Symfony', 'url' => 'https://symfony.com'],
+            ],
+        ]),
+    ]);
+
+    $result = (new ExaFindSimilar)->handle(new Request(['url' => 'https://laravel.com']));
+
+    expect($result)->toContain('Symfony');
+});
+
+it('sends the url and defaults', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('url', 'https://laravel.com')
+            ->toHaveKey('numResults', 10)
+            ->toHaveKey('contents', ['text' => true]);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaFindSimilar)->handle(new Request(['url' => 'https://laravel.com']));
+});
+
+it('parses comma-separated include and exclude domains', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('includeDomains', ['arxiv.org', 'nature.com'])
+            ->toHaveKey('excludeDomains', ['reddit.com']);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaFindSimilar)->handle(new Request([
+        'url' => 'https://laravel.com',
+        'include_domains' => 'arxiv.org, nature.com',
+        'exclude_domains' => 'reddit.com',
+    ]));
+});
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake([
+        'https://api.exa.ai/findSimilar' => Http::response('Bad request', 400),
+    ]);
+
+    $result = (new ExaFindSimilar)->handle(new Request(['url' => 'https://laravel.com']));
+
+    expect($result)->toContain('failed with status 400');
+});
+
+it('clamps num_results between 1 and 25', function (int $input, int $expected): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) use ($expected) {
+        expect($request->data())->toHaveKey('numResults', $expected);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaFindSimilar)->handle(new Request(['url' => 'https://laravel.com', 'num_results' => $input]));
+})->with([
+    'too low' => [0, 1],
+    'too high' => [100, 25],
+]);

--- a/src/Exa/tests/ExaGetContentsTest.php
+++ b/src/Exa/tests/ExaGetContentsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Exa\ExaGetContents;
+
+it('has a description', function (): void {
+    expect((new ExaGetContents)->description())->toContain('contents');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new ExaGetContents))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new ExaGetContents)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('urls')
+        ->and($schema)->toHaveKey('text')
+        ->and($schema)->toHaveKey('summary')
+        ->and($schema)->toHaveKey('highlights')
+        ->and($schema)->toHaveKey('livecrawl');
+});
+
+it('returns an error when urls are empty', function (): void {
+    $result = (new ExaGetContents)->handle(new Request(['urls' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.exa.key');
+
+    $result = (new ExaGetContents)->handle(new Request(['urls' => 'https://laravel.com']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('rejects more than 20 urls', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    $urls = implode(',', array_map(fn (int $i): string => 'https://example.com/'.$i, range(1, 21)));
+
+    $result = (new ExaGetContents)->handle(new Request(['urls' => $urls]));
+
+    expect($result)->toContain('maximum of 20');
+});
+
+it('returns contents on success', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake([
+        'https://api.exa.ai/contents' => Http::response([
+            'results' => [
+                ['url' => 'https://laravel.com', 'text' => 'The PHP framework.'],
+            ],
+        ]),
+    ]);
+
+    $result = (new ExaGetContents)->handle(new Request(['urls' => 'https://laravel.com']));
+
+    expect($result)->toContain('The PHP framework.');
+});
+
+it('sends urls as an array with defaults', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('urls', ['https://a.com', 'https://b.com'])
+            ->toHaveKey('text', true)
+            ->toHaveKey('livecrawl', 'fallback')
+            ->not->toHaveKey('summary')
+            ->not->toHaveKey('highlights');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaGetContents)->handle(new Request(['urls' => 'https://a.com, https://b.com']));
+});
+
+it('sends text as false when explicitly disabled', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('text', false);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaGetContents)->handle(new Request(['urls' => 'https://laravel.com', 'text' => false]));
+});
+
+it('includes summary and highlights when requested', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('summary', true)
+            ->toHaveKey('highlights', true);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaGetContents)->handle(new Request([
+        'urls' => 'https://laravel.com',
+        'summary' => true,
+        'highlights' => true,
+    ]));
+});
+
+it('falls back to fallback for invalid livecrawl values', function (string $input): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('livecrawl', 'fallback');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaGetContents)->handle(new Request(['urls' => 'https://laravel.com', 'livecrawl' => $input]));
+})->with([
+    'empty' => [''],
+    'random' => ['sometimes'],
+]);
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake([
+        'https://api.exa.ai/contents' => Http::response('Server error', 500),
+    ]);
+
+    $result = (new ExaGetContents)->handle(new Request(['urls' => 'https://laravel.com']));
+
+    expect($result)->toContain('failed with status 500');
+});

--- a/src/Exa/tests/ExaSearchTest.php
+++ b/src/Exa/tests/ExaSearchTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Exa\ExaSearch;
+
+it('has a description', function (): void {
+    expect((new ExaSearch)->description())->toContain('Search the web');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new ExaSearch))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new ExaSearch)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('query')
+        ->and($schema)->toHaveKey('type')
+        ->and($schema)->toHaveKey('num_results')
+        ->and($schema)->toHaveKey('category')
+        ->and($schema)->toHaveKey('include_domains')
+        ->and($schema)->toHaveKey('exclude_domains')
+        ->and($schema)->toHaveKey('include_text');
+});
+
+it('returns an error when the query is empty', function (): void {
+    $result = (new ExaSearch)->handle(new Request(['query' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.exa.key');
+
+    $result = (new ExaSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('returns search results on success', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake([
+        'https://api.exa.ai/search' => Http::response([
+            'results' => [
+                [
+                    'title' => 'Laravel 12 Released',
+                    'url' => 'https://laravel.com',
+                    'text' => 'Laravel 12 is here with new features.',
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = (new ExaSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('Laravel 12 Released')
+        ->and($result)->toContain('Laravel 12 is here');
+});
+
+it('sends the api key in the x-api-key header', function (): void {
+    config()->set('services.exa.key', 'secret-key');
+
+    Http::fake(function ($request) {
+        expect($request->header('x-api-key'))->toContain('secret-key');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaSearch)->handle(new Request(['query' => 'test']));
+});
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake([
+        'https://api.exa.ai/search' => Http::response('Invalid API key', 401),
+    ]);
+
+    $result = (new ExaSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('failed with status 401');
+});
+
+it('uses defaults when optional params are omitted', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('type', 'auto')
+            ->toHaveKey('numResults', 10)
+            ->toHaveKey('contents', ['text' => true]);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaSearch)->handle(new Request(['query' => 'test']));
+});
+
+it('uses defaults when optional params are explicitly null', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('type', 'auto')
+            ->toHaveKey('numResults', 10);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaSearch)->handle(new Request([
+        'query' => 'test',
+        'type' => null,
+        'num_results' => null,
+        'category' => null,
+        'include_domains' => null,
+        'exclude_domains' => null,
+        'include_text' => null,
+    ]));
+});
+
+it('omits contents when include_text is false', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->not->toHaveKey('contents');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaSearch)->handle(new Request(['query' => 'test', 'include_text' => false]));
+});
+
+it('parses comma-separated include and exclude domains', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('includeDomains', ['arxiv.org', 'nature.com'])
+            ->toHaveKey('excludeDomains', ['reddit.com']);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaSearch)->handle(new Request([
+        'query' => 'test',
+        'include_domains' => 'arxiv.org, nature.com',
+        'exclude_domains' => 'reddit.com',
+    ]));
+});
+
+it('drops an invalid category', function (): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->not->toHaveKey('category');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaSearch)->handle(new Request(['query' => 'test', 'category' => 'not-a-category']));
+});
+
+it('falls back to auto for invalid type values', function (string $input): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('type', 'auto');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaSearch)->handle(new Request(['query' => 'test', 'type' => $input]));
+})->with([
+    'empty' => [''],
+    'random' => ['foobar'],
+    'wrong case' => ['Neural'],
+]);
+
+it('clamps num_results between 1 and 25', function (int $input, int $expected): void {
+    config()->set('services.exa.key', 'test-key');
+
+    Http::fake(function ($request) use ($expected) {
+        expect($request->data())->toHaveKey('numResults', $expected);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new ExaSearch)->handle(new Request(['query' => 'test', 'num_results' => $input]));
+})->with([
+    'too low' => [-5, 1],
+    'zero' => [0, 1],
+    'minimum' => [1, 1],
+    'maximum' => [25, 25],
+    'too high' => [100, 25],
+]);

--- a/src/Exa/tests/ExaTest.php
+++ b/src/Exa/tests/ExaTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Shipfastlabs\Toolkit\Exa\Exa;
+use Shipfastlabs\Toolkit\Exa\ExaAnswer;
+use Shipfastlabs\Toolkit\Exa\ExaFindSimilar;
+use Shipfastlabs\Toolkit\Exa\ExaGetContents;
+use Shipfastlabs\Toolkit\Exa\ExaSearch;
+
+it('creates a collection of all Exa tools', function (): void {
+    $tools = Exa::all();
+
+    expect($tools)->toBeInstanceOf(Collection::class)
+        ->and($tools)->toHaveCount(4)
+        ->and($tools->all())->toContainOnlyInstancesOf(Tool::class);
+});
+
+it('includes each Exa tool exactly once', function (): void {
+    $classes = Exa::all()->map(fn ($tool): string => $tool::class);
+
+    expect($classes->all())->toEqualCanonicalizing([
+        ExaSearch::class,
+        ExaFindSimilar::class,
+        ExaGetContents::class,
+        ExaAnswer::class,
+    ]);
+});

--- a/workbench/app/Ai/Agents/ToolkitAgent.php
+++ b/workbench/app/Ai/Agents/ToolkitAgent.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Promptable;
 use Shipfastlabs\Toolkit\Calculator\CalculatorTool;
 use Shipfastlabs\Toolkit\Database\DatabaseQueryTool;
+use Shipfastlabs\Toolkit\Exa\Exa;
 use Shipfastlabs\Toolkit\Tavily\Tavily;
 
 /**
@@ -37,6 +38,7 @@ class ToolkitAgent implements Agent, HasTools
             new CalculatorTool,
             new DatabaseQueryTool,
             ...Tavily::all(),
+            ...Exa::all(),
         ];
     }
 }

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -20,6 +20,7 @@ class WorkbenchServiceProvider extends ServiceProvider
 
         config([
             'services.tavily.key' => env('TAVILY_API_KEY'),
+            'services.exa.key' => env('EXA_API_KEY'),
             'ai.providers.openai.key' => env('OPENAI_API_KEY'),
         ]);
     }


### PR DESCRIPTION
Currently the toolkit only ships Tavily for web tooling, so an agent that wants Exa's neural/semantic search, find-similar, content extraction, or a sourced answer has nothing to reach for. This adds a `shipfastlabs/toolkit-exa` package that mirrors `src/Tavily/` and the Exa AI SDK.

Four tools, registered together or one at a time:

```php
use Shipfastlabs\Toolkit\Exa\Exa;

$tools = Exa::all(); // ExaSearch, ExaFindSimilar, ExaGetContents, ExaAnswer
```

```php
use Shipfastlabs\Toolkit\Exa\ExaSearch;

$agent->tools([new ExaSearch]);
```

Credentials come from `services.exa.key`, optional defaults from `config('ai.toolkit.exa.*')`, both documented in the package README. No config files or providers shipped, same as Tavily.

A few notes:

- Tool and param descriptions follow the official Exa AI SDK wording, and every payload was checked against the Exa OpenAPI spec.
- That check turned up one thing: `/answer` has no `model` field, so an `exa`/`exa-pro` param would have been silently ignored by the API. Left it out rather than ship a dead option.
- Shared API key handling, the HTTP client, and request/response decoding live in an `InteractsWithExa` trait so the four tools stay thin.
- Worth flagging a structural difference: the Exa SDK only exposes `query` to the model and treats everything else as creation-time config. Here I surface `type`, `num_results`, domains, etc. as schema params so the model can drive them, which fits how Laravel AI tools work. Open to trimming these back to match the SDK if you'd prefer.
