### PR TITLE
Add Perplexity toolkit with Search and Ask tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,7 @@ TAVILY_API_KEY=
 
 EXA_API_KEY=
 
+# Perplexity API key (https://www.perplexity.ai/account/api)
+PERPLEXITY_API_KEY=
+
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Toolkit is a community catalog of reusable AI tools for the [Laravel AI SDK](htt
 | `TavilyExtract` | Extract clean, structured content from URLs. |
 | `TavilyCrawl` | Intelligently crawl a website and extract content. |
 | `TavilyMap` | Discover and map a website's structure. |
+| `PerplexitySearch` | Search the web for real-time information using [Perplexity](https://perplexity.ai). |
+| `PerplexityAsk` | Ask a question and get a direct, cited answer from Perplexity's Sonar models. |
 
 ## Official Documentation
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,7 @@ Toolkit is a community catalog of reusable AI tools for the [Laravel AI SDK](htt
 
 ## Available Tools
 
-| Tool | Description |
-|------|-------------|
-| `CalculatorTool` | Evaluate mathematical expressions with perfect accuracy. Supports `+`, `-`, `*`, `/`, `%`, `^`, parentheses, and decimals. |
-| `DatabaseQueryTool` | Run read-only `SELECT` queries against your Laravel database and return results as JSON. |
-| `TavilySearch` | Search the web for real-time information using [Tavily](https://tavily.com). |
-| `TavilyExtract` | Extract clean, structured content from URLs. |
-| `TavilyCrawl` | Intelligently crawl a website and extract content. |
-| `TavilyMap` | Discover and map a website's structure. |
-| `PerplexitySearch` | Search the web for real-time information using [Perplexity](https://perplexity.ai). |
-| `PerplexityAsk` | Ask a question and get a direct, cited answer from Perplexity's Sonar models. |
+Browse the full, always-up-to-date catalog of tools on the [documentation site](https://toolkit.shipfastlabs.com).
 
 ## Official Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "shipfastlabs/toolkit-calculator": "self.version",
         "shipfastlabs/toolkit-database": "self.version",
         "shipfastlabs/toolkit-exa": "self.version",
+        "shipfastlabs/toolkit-perplexity": "self.version",
         "shipfastlabs/toolkit-stub": "self.version",
         "shipfastlabs/toolkit-tavily": "self.version"
     },
@@ -45,6 +46,7 @@
             "Shipfastlabs\\Toolkit\\Calculator\\": "src/Calculator/src/",
             "Shipfastlabs\\Toolkit\\Database\\": "src/Database/src/",
             "Shipfastlabs\\Toolkit\\Exa\\": "src/Exa/src/",
+            "Shipfastlabs\\Toolkit\\Perplexity\\": "src/Perplexity/src/",
             "Shipfastlabs\\Toolkit\\Tavily\\": "src/Tavily/src/"
         }
     },
@@ -53,6 +55,7 @@
             "Shipfastlabs\\Toolkit\\Calculator\\Tests\\": "src/Calculator/tests/",
             "Shipfastlabs\\Toolkit\\Database\\Tests\\": "src/Database/tests/",
             "Shipfastlabs\\Toolkit\\Exa\\Tests\\": "src/Exa/tests/",
+            "Shipfastlabs\\Toolkit\\Perplexity\\Tests\\": "src/Perplexity/tests/",
             "Shipfastlabs\\Toolkit\\Tavily\\Tests\\": "src/Tavily/tests/",
             "Shipfastlabs\\Toolkit\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/",

--- a/docs/tools/perplexity.md
+++ b/docs/tools/perplexity.md
@@ -1,0 +1,138 @@
+# Perplexity
+
+> Perplexity tools for the Laravel AI SDK - Search and Ask (Sonar)
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-perplexity
+```
+
+## Usage
+
+Register every Perplexity tool at once with the `Perplexity` helper:
+
+```php
+use Shipfastlabs\Toolkit\Perplexity\Perplexity;
+
+$tools = Perplexity::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\Perplexity\PerplexitySearch;
+use Shipfastlabs\Toolkit\Perplexity\PerplexityAsk;
+
+$tools = [
+    new PerplexitySearch,
+    new PerplexityAsk,
+];
+```
+
+## Tools
+
+### PerplexitySearch
+
+Search the web for real-time information and get a ranked list of sources. Uses the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | yes | The search query to look up on the web. |
+| `max_results` | integer | no | Maximum number of results to return (1-20). Defaults to 10. |
+| `search_recency_filter` | string | no | Restrict results to a recent window: `"hour"`, `"day"`, `"week"`, `"month"`, or `"year"`. No filter by default. |
+
+### PerplexityAsk
+
+Ask a question and get a direct, cited answer grounded in a live web search using Perplexity's [Sonar models](https://docs.perplexity.ai/api-reference/chat-completions-post). The response includes the answer text plus the `search_results` and `citations` used.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | yes | The question to ask Perplexity. |
+| `model` | string | no | Sonar model: `"sonar"`, `"sonar-pro"`, `"sonar-reasoning"`, `"sonar-reasoning-pro"`, or `"sonar-deep-research"`. Defaults to `"sonar"`. |
+| `search_mode` | string | no | `"web"` for the open web, `"academic"` for scholarly sources, or `"sec"` for SEC filings. Defaults to `"web"`. |
+
+## Provider setup
+
+Both tools read their API key from Laravel's `services` config and their optional defaults from the `ai` config.
+
+### 1. Add the Perplexity service to `config/services.php`
+
+```php
+// config/services.php
+
+return [
+
+    // ... existing services ...
+
+    'perplexity' => [
+        'key' => env('PERPLEXITY_API_KEY'),
+    ],
+
+];
+```
+
+### 2. Add toolkit defaults to `config/ai.php`
+
+```php
+// config/ai.php
+
+return [
+
+    // ... existing laravel/ai config ...
+
+    'toolkit' => [
+        'perplexity' => [
+            'search' => [
+                'max_results' => (int) env('PERPLEXITY_SEARCH_MAX_RESULTS', 10),
+                'recency' => env('PERPLEXITY_SEARCH_RECENCY'),
+            ],
+            'ask' => [
+                'model' => env('PERPLEXITY_ASK_MODEL', 'sonar'),
+                'search_mode' => env('PERPLEXITY_ASK_SEARCH_MODE', 'web'),
+            ],
+        ],
+    ],
+
+];
+```
+
+### 3. Add environment variables to `.env`
+
+```dotenv
+PERPLEXITY_API_KEY=pplx-your-key-here
+
+# Search defaults
+PERPLEXITY_SEARCH_MAX_RESULTS=10
+PERPLEXITY_SEARCH_RECENCY=
+
+# Ask defaults
+PERPLEXITY_ASK_MODEL=sonar
+PERPLEXITY_ASK_SEARCH_MODE=web
+```
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `services.perplexity.key` | `PERPLEXITY_API_KEY` | - | **Required.** Your Perplexity API key. |
+| `ai.toolkit.perplexity.search.max_results` | `PERPLEXITY_SEARCH_MAX_RESULTS` | `10` | Default search results (1-20). |
+| `ai.toolkit.perplexity.search.recency` | `PERPLEXITY_SEARCH_RECENCY` | - | Default recency filter (`hour`/`day`/`week`/`month`/`year`). |
+| `ai.toolkit.perplexity.ask.model` | `PERPLEXITY_ASK_MODEL` | `"sonar"` | Default Sonar model. |
+| `ai.toolkit.perplexity.ask.search_mode` | `PERPLEXITY_ASK_SEARCH_MODE` | `"web"` | Default search mode (`web`/`academic`/`sec`). |
+
+## Safety
+
+- Both tools validate required inputs before calling the API.
+- `max_results` is clamped to its valid 1-20 range.
+- `model`, `search_mode`, and `search_recency_filter` are validated against allow-lists, falling back to safe defaults.
+- API errors are caught and returned as friendly string messages.
+- Requires a valid Perplexity API key.
+
+## Perplexity API
+
+These tools use the [Perplexity API](https://docs.perplexity.ai). You'll need an API key from your [Perplexity account settings](https://www.perplexity.ai/account/api).
+
+Full API reference:
+- [Search Endpoint](https://docs.perplexity.ai/api-reference/search-post)
+- [Chat Completions Endpoint](https://docs.perplexity.ai/api-reference/chat-completions-post)

--- a/src/Perplexity/README.md
+++ b/src/Perplexity/README.md
@@ -1,0 +1,143 @@
+# shipfastlabs/toolkit-perplexity
+
+[![Latest Version](https://img.shields.io/packagist/v/shipfastlabs/toolkit-perplexity.svg)](https://packagist.org/packages/shipfastlabs/toolkit-perplexity)
+[![Total Downloads](https://img.shields.io/packagist/dt/shipfastlabs/toolkit-perplexity.svg)](https://packagist.org/packages/shipfastlabs/toolkit-perplexity)
+
+> Perplexity tools for the Laravel AI SDK - Search and Ask (Sonar)
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+<!-- AUTO-GENERATED: do not edit above this line. Run `tools/docgen.sh`. -->
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-perplexity
+```
+
+## Usage
+
+Register every Perplexity tool at once with the `Perplexity` helper:
+
+```php
+use Shipfastlabs\Toolkit\Perplexity\Perplexity;
+
+$tools = Perplexity::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\Perplexity\PerplexitySearch;
+use Shipfastlabs\Toolkit\Perplexity\PerplexityAsk;
+
+$tools = [
+    new PerplexitySearch,
+    new PerplexityAsk,
+];
+```
+
+## Tools
+
+### PerplexitySearch
+
+Search the web for real-time information and get a ranked list of sources. Uses the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | yes | The search query to look up on the web. |
+| `max_results` | integer | no | Maximum number of results to return (1-20). Defaults to 10. |
+| `search_recency_filter` | string | no | Restrict results to a recent window: `"hour"`, `"day"`, `"week"`, `"month"`, or `"year"`. No filter by default. |
+
+### PerplexityAsk
+
+Ask a question and get a direct, cited answer grounded in a live web search using Perplexity's [Sonar models](https://docs.perplexity.ai/api-reference/chat-completions-post). The response includes the answer text plus the `search_results` and `citations` used.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | yes | The question to ask Perplexity. |
+| `model` | string | no | Sonar model: `"sonar"`, `"sonar-pro"`, `"sonar-reasoning"`, `"sonar-reasoning-pro"`, or `"sonar-deep-research"`. Defaults to `"sonar"`. |
+| `search_mode` | string | no | `"web"` for the open web, `"academic"` for scholarly sources, or `"sec"` for SEC filings. Defaults to `"web"`. |
+
+## Provider setup
+
+Both tools read their API key from Laravel's `services` config and their optional defaults from the `ai` config.
+
+### 1. Add the Perplexity service to `config/services.php`
+
+```php
+// config/services.php
+
+return [
+
+    // ... existing services ...
+
+    'perplexity' => [
+        'key' => env('PERPLEXITY_API_KEY'),
+    ],
+
+];
+```
+
+### 2. Add toolkit defaults to `config/ai.php`
+
+```php
+// config/ai.php
+
+return [
+
+    // ... existing laravel/ai config ...
+
+    'toolkit' => [
+        'perplexity' => [
+            'search' => [
+                'max_results' => (int) env('PERPLEXITY_SEARCH_MAX_RESULTS', 10),
+                'recency' => env('PERPLEXITY_SEARCH_RECENCY'),
+            ],
+            'ask' => [
+                'model' => env('PERPLEXITY_ASK_MODEL', 'sonar'),
+                'search_mode' => env('PERPLEXITY_ASK_SEARCH_MODE', 'web'),
+            ],
+        ],
+    ],
+
+];
+```
+
+### 3. Add environment variables to `.env`
+
+```dotenv
+PERPLEXITY_API_KEY=pplx-your-key-here
+
+# Search defaults
+PERPLEXITY_SEARCH_MAX_RESULTS=10
+PERPLEXITY_SEARCH_RECENCY=
+
+# Ask defaults
+PERPLEXITY_ASK_MODEL=sonar
+PERPLEXITY_ASK_SEARCH_MODE=web
+```
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `services.perplexity.key` | `PERPLEXITY_API_KEY` | - | **Required.** Your Perplexity API key. |
+| `ai.toolkit.perplexity.search.max_results` | `PERPLEXITY_SEARCH_MAX_RESULTS` | `10` | Default search results (1-20). |
+| `ai.toolkit.perplexity.search.recency` | `PERPLEXITY_SEARCH_RECENCY` | - | Default recency filter (`hour`/`day`/`week`/`month`/`year`). |
+| `ai.toolkit.perplexity.ask.model` | `PERPLEXITY_ASK_MODEL` | `"sonar"` | Default Sonar model. |
+| `ai.toolkit.perplexity.ask.search_mode` | `PERPLEXITY_ASK_SEARCH_MODE` | `"web"` | Default search mode (`web`/`academic`/`sec`). |
+
+## Safety
+
+- Both tools validate required inputs before calling the API.
+- `max_results` is clamped to its valid 1-20 range.
+- `model`, `search_mode`, and `search_recency_filter` are validated against allow-lists, falling back to safe defaults.
+- API errors are caught and returned as friendly string messages.
+- Requires a valid Perplexity API key.
+
+## Perplexity API
+
+These tools use the [Perplexity API](https://docs.perplexity.ai). You'll need an API key from your [Perplexity account settings](https://www.perplexity.ai/account/api).
+
+Full API reference:
+- [Search Endpoint](https://docs.perplexity.ai/api-reference/search-post)
+- [Chat Completions Endpoint](https://docs.perplexity.ai/api-reference/chat-completions-post)

--- a/src/Perplexity/composer.json
+++ b/src/Perplexity/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "shipfastlabs/toolkit-perplexity",
+    "description": "Perplexity tools for the Laravel AI SDK - Search and Ask (Sonar)",
+    "keywords": ["laravel", "ai", "tool", "perplexity", "sonar", "search", "answer"],
+    "license": "MIT",
+    "require": {
+        "php": "^8.4.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "laravel/ai": "^0.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Perplexity\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Perplexity\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/Perplexity/src/Perplexity.php
+++ b/src/Perplexity/src/Perplexity.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Perplexity;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+
+class Perplexity
+{
+    /**
+     * @return Collection<int, Tool>
+     */
+    public static function all(): Collection
+    {
+        return new Collection([
+            new PerplexitySearch,
+            new PerplexityAsk,
+        ]);
+    }
+}

--- a/src/Perplexity/src/PerplexityAsk.php
+++ b/src/Perplexity/src/PerplexityAsk.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Perplexity;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Throwable;
+
+#[Strict]
+class PerplexityAsk implements Tool
+{
+    public function description(): string
+    {
+        return <<<'TXT'
+            Ask Perplexity a question and get a direct, cited answer grounded in a live
+            web search using its Sonar models. Returns the answer text along with the
+            search results and source citations used.
+            TXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema
+                ->string()
+                ->description('The question to ask Perplexity')
+                ->required(),
+            'model' => $schema
+                ->string()
+                ->description("The Sonar model to use - one of 'sonar', 'sonar-pro', 'sonar-reasoning', 'sonar-reasoning-pro', or 'sonar-deep-research' (default: 'sonar')")
+                ->nullable()
+                ->required(),
+            'search_mode' => $schema
+                ->string()
+                ->description("The search mode - 'web' for the open web, 'academic' for scholarly sources, or 'sec' for SEC filings (default: 'web')")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $query = $request->string('query')->trim();
+
+        if ($query->isEmpty()) {
+            return 'The question is empty. Provide a question to ask Perplexity.';
+        }
+
+        $apiKey = config('services.perplexity.key');
+
+        if (! is_string($apiKey) || blank($apiKey)) {
+            return 'The Perplexity tool is not configured. Set services.perplexity.key in your config/services.php file.';
+        }
+
+        $model = $request->filled('model')
+            ? $this->validateModel((string) $request->string('model'))
+            : $this->defaultModel();
+
+        $searchMode = $request->filled('search_mode')
+            ? $this->validateSearchMode((string) $request->string('search_mode'))
+            : $this->defaultSearchMode();
+
+        try {
+            $response = Http::withToken($apiKey)
+                ->timeout(60)
+                ->post('https://api.perplexity.ai/chat/completions', [
+                    'model' => $model,
+                    'search_mode' => $searchMode,
+                    'messages' => [
+                        ['role' => 'user', 'content' => (string) $query],
+                    ],
+                ]);
+        } catch (Throwable $throwable) {
+            return sprintf('The Perplexity request failed: %s', $throwable->getMessage());
+        }
+
+        if ($response->failed()) {
+            return sprintf(
+                'The Perplexity request failed with status %d: %s',
+                $response->status(),
+                $response->body()
+            );
+        }
+
+        $data = $response->json();
+
+        if (! is_array($data)) {
+            return 'The Perplexity response was invalid.';
+        }
+
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    private function defaultModel(): string
+    {
+        $model = config('ai.toolkit.perplexity.ask.model', 'sonar');
+
+        return $this->validateModel(is_string($model) ? $model : 'sonar');
+    }
+
+    private function validateModel(string $model): string
+    {
+        $allowed = ['sonar', 'sonar-pro', 'sonar-reasoning', 'sonar-reasoning-pro', 'sonar-deep-research'];
+
+        return in_array($model, $allowed, true) ? $model : 'sonar';
+    }
+
+    private function defaultSearchMode(): string
+    {
+        $mode = config('ai.toolkit.perplexity.ask.search_mode', 'web');
+
+        return $this->validateSearchMode(is_string($mode) ? $mode : 'web');
+    }
+
+    private function validateSearchMode(string $mode): string
+    {
+        return in_array($mode, ['web', 'academic', 'sec'], true) ? $mode : 'web';
+    }
+}

--- a/src/Perplexity/src/PerplexitySearch.php
+++ b/src/Perplexity/src/PerplexitySearch.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Perplexity;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Throwable;
+
+#[Strict]
+class PerplexitySearch implements Tool
+{
+    public function description(): string
+    {
+        return <<<'TXT'
+            Search the web for real-time information using the Perplexity Search API.
+            Returns a ranked list of sources with titles, URLs, and snippets.
+            TXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema
+                ->string()
+                ->description('The search query to look up on the web')
+                ->required(),
+            'max_results' => $schema
+                ->integer()
+                ->description('Maximum number of search results to return (1-20, default: 10)')
+                ->nullable()
+                ->required(),
+            'search_recency_filter' => $schema
+                ->string()
+                ->description("Restrict results to a recent time window - one of 'hour', 'day', 'week', 'month', or 'year' (default: no filter)")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $query = $request->string('query')->trim();
+
+        if ($query->isEmpty()) {
+            return 'The search query is empty. Provide a query to search for.';
+        }
+
+        $apiKey = config('services.perplexity.key');
+
+        if (! is_string($apiKey) || blank($apiKey)) {
+            return 'The Perplexity tool is not configured. Set services.perplexity.key in your config/services.php file.';
+        }
+
+        $maxResults = $request->filled('max_results')
+            ? $request->integer('max_results')
+            : $this->defaultMaxResults();
+
+        $payload = [
+            'query' => (string) $query,
+            'max_results' => max(1, min(20, $maxResults)),
+        ];
+
+        $recency = $request->filled('search_recency_filter')
+            ? $this->validateRecency((string) $request->string('search_recency_filter'))
+            : $this->defaultRecency();
+
+        if ($recency !== null) {
+            $payload['search_recency_filter'] = $recency;
+        }
+
+        try {
+            $response = Http::withToken($apiKey)
+                ->timeout(30)
+                ->post('https://api.perplexity.ai/search', $payload);
+        } catch (Throwable $throwable) {
+            return sprintf('The Perplexity search request failed: %s', $throwable->getMessage());
+        }
+
+        if ($response->failed()) {
+            return sprintf(
+                'The Perplexity search request failed with status %d: %s',
+                $response->status(),
+                $response->body()
+            );
+        }
+
+        $data = $response->json();
+
+        if (! is_array($data)) {
+            return 'The Perplexity search response was invalid.';
+        }
+
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    private function defaultMaxResults(): int
+    {
+        $max = config('ai.toolkit.perplexity.search.max_results', 10);
+
+        return is_numeric($max) ? (int) $max : 10;
+    }
+
+    private function defaultRecency(): ?string
+    {
+        $recency = config('ai.toolkit.perplexity.search.recency');
+
+        return is_string($recency) ? $this->validateRecency($recency) : null;
+    }
+
+    private function validateRecency(string $recency): ?string
+    {
+        return in_array($recency, ['hour', 'day', 'week', 'month', 'year'], true) ? $recency : null;
+    }
+}

--- a/src/Perplexity/tests/PerplexityAskTest.php
+++ b/src/Perplexity/tests/PerplexityAskTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Perplexity\PerplexityAsk;
+
+it('has a description', function (): void {
+    expect((new PerplexityAsk)->description())->toContain('cited answer');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new PerplexityAsk))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new PerplexityAsk)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('query')
+        ->and($schema)->toHaveKey('model')
+        ->and($schema)->toHaveKey('search_mode');
+});
+
+it('returns an error when the question is empty', function (): void {
+    $result = (new PerplexityAsk)->handle(new Request(['query' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.perplexity.key');
+
+    $result = (new PerplexityAsk)->handle(new Request(['query' => 'Who created Laravel?']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('returns an answer on success', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake([
+        'https://api.perplexity.ai/chat/completions' => Http::response([
+            'choices' => [
+                ['message' => ['role' => 'assistant', 'content' => 'Laravel was created by Taylor Otwell.']],
+            ],
+            'citations' => ['https://laravel.com'],
+        ]),
+    ]);
+
+    $result = (new PerplexityAsk)->handle(new Request(['query' => 'Who created Laravel?']));
+
+    expect($result)->toContain('Taylor Otwell')
+        ->and($result)->toContain('https://laravel.com');
+});
+
+it('sends the question as a user message', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data()['messages'])->toBe([
+            ['role' => 'user', 'content' => 'Who created Laravel?'],
+        ]);
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request(['query' => 'Who created Laravel?']));
+});
+
+it('sends the api key as a bearer token', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->hasHeader('Authorization', 'Bearer test-key'))->toBeTrue();
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request(['query' => 'test']));
+});
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake([
+        'https://api.perplexity.ai/chat/completions' => Http::response('Invalid API key', 401),
+    ]);
+
+    $result = (new PerplexityAsk)->handle(new Request(['query' => 'test']));
+
+    expect($result)->toContain('failed with status 401');
+});
+
+it('returns an error when the response is not an array', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake([
+        'https://api.perplexity.ai/chat/completions' => Http::response('"plain string"', 200, ['Content-Type' => 'application/json']),
+    ]);
+
+    $result = (new PerplexityAsk)->handle(new Request(['query' => 'test']));
+
+    expect($result)->toContain('invalid');
+});
+
+it('respects a custom model', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('model', 'sonar-pro');
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request(['query' => 'test', 'model' => 'sonar-pro']));
+});
+
+it('respects a custom search_mode', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('search_mode', 'academic');
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request(['query' => 'test', 'search_mode' => 'academic']));
+});
+
+it('uses defaults when optional params are omitted', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('model', 'sonar')
+            ->toHaveKey('search_mode', 'web');
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request(['query' => 'test']));
+});
+
+it('uses defaults when optional params are explicitly null', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('model', 'sonar')
+            ->toHaveKey('search_mode', 'web');
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request([
+        'query' => 'test',
+        'model' => null,
+        'search_mode' => null,
+    ]));
+});
+
+it('reads the default model and search_mode from config', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+    config()->set('ai.toolkit.perplexity.ask.model', 'sonar-reasoning');
+    config()->set('ai.toolkit.perplexity.ask.search_mode', 'academic');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('model', 'sonar-reasoning')
+            ->toHaveKey('search_mode', 'academic');
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request(['query' => 'test']));
+});
+
+it('falls back to sonar when the configured model is invalid', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+    config()->set('ai.toolkit.perplexity.ask.model', 12345);
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('model', 'sonar');
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request(['query' => 'test']));
+});
+
+it('falls back to web when the configured search_mode is invalid', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+    config()->set('ai.toolkit.perplexity.ask.search_mode', ['not', 'a', 'string']);
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('search_mode', 'web');
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request(['query' => 'test']));
+});
+
+it('falls back to defaults for invalid model and search_mode values', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('model', 'sonar')
+            ->toHaveKey('search_mode', 'web');
+
+        return Http::response(['choices' => []]);
+    });
+
+    (new PerplexityAsk)->handle(new Request([
+        'query' => 'test',
+        'model' => 'gpt-4',
+        'search_mode' => 'telepathy',
+    ]));
+});
+
+it('returns a friendly error when the request throws', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function (): void {
+        throw new RuntimeException('Connection timed out');
+    });
+
+    $result = (new PerplexityAsk)->handle(new Request(['query' => 'test']));
+
+    expect($result)->toContain('request failed')
+        ->and($result)->toContain('Connection timed out');
+});

--- a/src/Perplexity/tests/PerplexitySearchTest.php
+++ b/src/Perplexity/tests/PerplexitySearchTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Perplexity\PerplexitySearch;
+
+it('has a description', function (): void {
+    expect((new PerplexitySearch)->description())->toContain('Search the web');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new PerplexitySearch))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new PerplexitySearch)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('query')
+        ->and($schema)->toHaveKey('max_results')
+        ->and($schema)->toHaveKey('search_recency_filter');
+});
+
+it('returns an error when the query is empty', function (): void {
+    $result = (new PerplexitySearch)->handle(new Request(['query' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.perplexity.key');
+
+    $result = (new PerplexitySearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('returns search results on success', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake([
+        'https://api.perplexity.ai/search' => Http::response([
+            'results' => [
+                [
+                    'title' => 'Laravel 11 Released',
+                    'url' => 'https://laravel.com',
+                    'snippet' => 'Laravel 11 is here with new features.',
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = (new PerplexitySearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('Laravel 11 Released')
+        ->and($result)->toContain('Laravel 11 is here');
+});
+
+it('sends the api key as a bearer token', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->hasHeader('Authorization', 'Bearer test-key'))->toBeTrue();
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request(['query' => 'test']));
+});
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake([
+        'https://api.perplexity.ai/search' => Http::response('Invalid API key', 401),
+    ]);
+
+    $result = (new PerplexitySearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('failed with status 401');
+});
+
+it('returns an error when the response is not an array', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake([
+        'https://api.perplexity.ai/search' => Http::response('"plain string"', 200, ['Content-Type' => 'application/json']),
+    ]);
+
+    $result = (new PerplexitySearch)->handle(new Request(['query' => 'test']));
+
+    expect($result)->toContain('invalid');
+});
+
+it('respects custom max_results', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('max_results', 3);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request(['query' => 'test', 'max_results' => 3]));
+});
+
+it('applies a valid recency filter', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('search_recency_filter', 'week');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request(['query' => 'test', 'search_recency_filter' => 'week']));
+});
+
+it('omits an invalid recency filter', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())->not->toHaveKey('search_recency_filter');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request(['query' => 'test', 'search_recency_filter' => 'decade']));
+});
+
+it('uses the configured default recency when omitted', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+    config()->set('ai.toolkit.perplexity.search.recency', 'month');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('search_recency_filter', 'month');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request(['query' => 'test']));
+});
+
+it('uses defaults when optional params are omitted', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('max_results', 10)
+            ->not->toHaveKey('search_recency_filter');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request(['query' => 'test']));
+});
+
+it('uses defaults when optional params are explicitly null', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) {
+        expect($request->data())
+            ->toHaveKey('max_results', 10)
+            ->not->toHaveKey('search_recency_filter');
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request([
+        'query' => 'test',
+        'max_results' => null,
+        'search_recency_filter' => null,
+    ]));
+});
+
+it('falls back to the default when configured max_results is not numeric', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+    config()->set('ai.toolkit.perplexity.search.max_results', 'not-a-number');
+
+    Http::fake(function ($request) {
+        expect($request->data())->toHaveKey('max_results', 10);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request(['query' => 'test']));
+});
+
+it('clamps max_results between 1 and 20', function (int $input, int $expected): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function ($request) use ($expected) {
+        expect($request->data())->toHaveKey('max_results', $expected);
+
+        return Http::response(['results' => []]);
+    });
+
+    (new PerplexitySearch)->handle(new Request(['query' => 'test', 'max_results' => $input]));
+})->with([
+    'too low' => [-5, 1],
+    'zero' => [0, 1],
+    'minimum' => [1, 1],
+    'maximum' => [20, 20],
+    'too high' => [50, 20],
+]);
+
+it('returns a friendly error when the request throws', function (): void {
+    config()->set('services.perplexity.key', 'test-key');
+
+    Http::fake(function (): void {
+        throw new RuntimeException('Connection timed out');
+    });
+
+    $result = (new PerplexitySearch)->handle(new Request(['query' => 'test']));
+
+    expect($result)->toContain('request failed')
+        ->and($result)->toContain('Connection timed out');
+});

--- a/src/Perplexity/tests/PerplexityTest.php
+++ b/src/Perplexity/tests/PerplexityTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Shipfastlabs\Toolkit\Perplexity\Perplexity;
+use Shipfastlabs\Toolkit\Perplexity\PerplexityAsk;
+use Shipfastlabs\Toolkit\Perplexity\PerplexitySearch;
+
+it('creates a collection of all Perplexity tools', function (): void {
+    $tools = Perplexity::all();
+
+    expect($tools)->toBeInstanceOf(Collection::class)
+        ->and($tools)->toHaveCount(2)
+        ->and($tools->all())->toContainOnlyInstancesOf(Tool::class);
+});
+
+it('includes each Perplexity tool exactly once', function (): void {
+    $classes = Perplexity::all()->map(fn ($tool): string => $tool::class);
+
+    expect($classes->all())->toEqualCanonicalizing([
+        PerplexitySearch::class,
+        PerplexityAsk::class,
+    ]);
+});

--- a/workbench/app/Ai/Agents/ToolkitAgent.php
+++ b/workbench/app/Ai/Agents/ToolkitAgent.php
@@ -11,6 +11,7 @@ use Laravel\Ai\Promptable;
 use Shipfastlabs\Toolkit\Calculator\CalculatorTool;
 use Shipfastlabs\Toolkit\Database\DatabaseQueryTool;
 use Shipfastlabs\Toolkit\Exa\Exa;
+use Shipfastlabs\Toolkit\Perplexity\Perplexity;
 use Shipfastlabs\Toolkit\Tavily\Tavily;
 
 /**
@@ -39,6 +40,7 @@ class ToolkitAgent implements Agent, HasTools
             new DatabaseQueryTool,
             ...Tavily::all(),
             ...Exa::all(),
+            ...Perplexity::all(),
         ];
     }
 }


### PR DESCRIPTION
Currently the toolkit covers web search via Tavily and Exa, but there's no Perplexity option, and Perplexity's Sonar models are a popular way to get a cited, ready-to-use answer rather than just a list of links. This PR adds a `shipfastlabs/toolkit-perplexity` package with two tools.

`PerplexitySearch` hits the Search API for ranked sources. `PerplexityAsk` hits the Sonar chat endpoint and returns a direct answer plus its `search_results` and `citations`.

```php
use Shipfastlabs\Toolkit\Perplexity\Perplexity;

$tools = Perplexity::all(); // PerplexitySearch + PerplexityAsk
```

Follows the existing package layout (standalone package, `#[Strict]`, config read from `services.perplexity.key` and `ai.toolkit.perplexity.*`), and the aggregator is `Perplexity::all()` to stay parallel with `Tavily::all()` and `Exa::all()`.

Full suite passes (Pint, Rector, PHPStan max, 100% type + code coverage).