### PR TITLE
Add JigsawStack toolkit with 18 AI SDK tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,7 @@ DB_CONNECTION=testing
 # Tavily API key (https://app.tavily.com)
 TAVILY_API_KEY=
 
+# JigsawStack API key (https://jigsawstack.com)
+JIGSAWSTACK_API_KEY=
+
 OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 .deepsec/
 docs/node_modules/
 .claude
+
+# Testbench workbench build artifact (machine-specific symlink)
+/workbench/storage

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "replace": {
         "shipfastlabs/toolkit-calculator": "self.version",
         "shipfastlabs/toolkit-database": "self.version",
+        "shipfastlabs/toolkit-jigsawstack": "self.version",
         "shipfastlabs/toolkit-stub": "self.version",
         "shipfastlabs/toolkit-tavily": "self.version"
     },
@@ -43,6 +44,7 @@
             "Shipfastlabs\\Toolkit\\": "src/",
             "Shipfastlabs\\Toolkit\\Calculator\\": "src/Calculator/src/",
             "Shipfastlabs\\Toolkit\\Database\\": "src/Database/src/",
+            "Shipfastlabs\\Toolkit\\JigsawStack\\": "src/JigsawStack/src/",
             "Shipfastlabs\\Toolkit\\Tavily\\": "src/Tavily/src/"
         }
     },
@@ -50,6 +52,7 @@
         "psr-4": {
             "Shipfastlabs\\Toolkit\\Calculator\\Tests\\": "src/Calculator/tests/",
             "Shipfastlabs\\Toolkit\\Database\\Tests\\": "src/Database/tests/",
+            "Shipfastlabs\\Toolkit\\JigsawStack\\Tests\\": "src/JigsawStack/tests/",
             "Shipfastlabs\\Toolkit\\Tavily\\Tests\\": "src/Tavily/tests/",
             "Shipfastlabs\\Toolkit\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/",

--- a/docs/tools/jigsawstack.md
+++ b/docs/tools/jigsawstack.md
@@ -1,0 +1,126 @@
+# Jigsawstack
+
+> JigsawStack tools for the Laravel AI SDK - sentiment, summary, embedding, translation, web search, scraping, vision, audio, and validation
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-jigsawstack
+```
+
+## Usage
+
+Register every JigsawStack tool at once with the `JigsawStack` helper:
+
+```php
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStack;
+
+$tools = JigsawStack::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackWebSearch;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSummary;
+
+$tools = [
+    new JigsawStackWebSearch,
+    new JigsawStackSummary,
+];
+```
+
+## Tools
+
+Each tool maps to a JigsawStack endpoint and returns the raw JSON response (pretty-printed) so the model can read every field.
+
+### General
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackSentiment` | `POST /v1/ai/sentiment` | `text` | — |
+| `JigsawStackSummary` | `POST /v1/ai/summary` | `text` | `type` (`text`\|`points`), `max_points` |
+| `JigsawStackEmbedding` | `POST /v1/embedding` | `text` | `type` (default `text`) |
+| `JigsawStackPrediction` | `POST /v1/ai/prediction` | `dataset` (JSON array of `{date,value}`) | `steps` |
+| `JigsawStackTextToSql` | `POST /v1/ai/sql` | `prompt` | `sql_schema`, `database` |
+
+### Translation
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackTranslateText` | `POST /v1/ai/translate` | `text`, `target_language` | `current_language` |
+| `JigsawStackTranslateImage` | `POST /v1/ai/translate/image` | `url`, `target_language` | — |
+
+### Web
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackWebSearch` | `POST /v1/web/search` | `query` | `ai_overview`, `safe_search`, `max_results` |
+| `JigsawStackAiScrape` | `POST /v1/ai/scrape` | `url`, `element_prompts` (comma-separated) | `root_element_selector` |
+| `JigsawStackHtmlToAny` | `POST /v1/web/html_to_any` | `html` | `type` (`png`\|`jpeg`\|`webp`\|`pdf`), `full_page` |
+| `JigsawStackSearchSuggestions` | `GET /v1/web/search/suggest` | `query` | — |
+
+### Vision
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackVocr` | `POST /v1/vocr` | `url` | `prompt` |
+| `JigsawStackObjectDetection` | `POST /v1/object_detection` | `url` | `prompts` (comma-separated), `annotated_image` |
+
+### Audio
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackSpeechToText` | `POST /v1/ai/transcribe` | `url` | `language`, `translate` |
+
+### Validation
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackNsfwDetection` | `POST /v1/validate/nsfw` | `url` | — |
+| `JigsawStackProfanityCheck` | `POST /v1/validate/profanity` | `text` | `censor_replacement` |
+| `JigsawStackSpellCheck` | `POST /v1/validate/spell_check` | `text` | `language_code` |
+| `JigsawStackSpamCheck` | `POST /v1/validate/spam_check` | `text` | — |
+
+## Configuration
+
+Every tool reads its API key from Laravel's `services` config.
+
+### 1. Add the JigsawStack service to `config/services.php`
+
+```php
+// config/services.php
+
+return [
+
+    // ... existing services ...
+
+    'jigsawstack' => [
+        'key' => env('JIGSAWSTACK_API_KEY'),
+    ],
+
+];
+```
+
+### 2. Add the environment variable to `.env`
+
+```dotenv
+JIGSAWSTACK_API_KEY=your-key-here
+```
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `services.jigsawstack.key` | `JIGSAWSTACK_API_KEY` | - | **Required.** Your JigsawStack API key, sent as the `x-api-key` header. |
+
+## Safety
+
+- All tools validate required inputs before calling the API.
+- Requests time out after 60 seconds.
+- API errors and network failures are caught and returned as friendly string messages so the model can recover.
+- Requires a valid JigsawStack API key; tools return a clear "not configured" message when it is missing.
+
+## JigsawStack API
+
+These tools use the [JigsawStack API](https://jigsawstack.com/docs). See the [API reference](https://jigsawstack.com/docs/api-reference) for full details on each endpoint and its response shape.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
         <include>
             <directory suffix=".php">./src/Calculator/src</directory>
             <directory suffix=".php">./src/Database/src</directory>
+            <directory suffix=".php">./src/JigsawStack/src</directory>
         </include>
     </source>
     <testsuites>

--- a/src/JigsawStack/README.md
+++ b/src/JigsawStack/README.md
@@ -1,0 +1,131 @@
+# shipfastlabs/toolkit-jigsawstack
+
+[![Latest Version](https://img.shields.io/packagist/v/shipfastlabs/toolkit-jigsawstack.svg)](https://packagist.org/packages/shipfastlabs/toolkit-jigsawstack)
+[![Total Downloads](https://img.shields.io/packagist/dt/shipfastlabs/toolkit-jigsawstack.svg)](https://packagist.org/packages/shipfastlabs/toolkit-jigsawstack)
+
+> JigsawStack tools for the Laravel AI SDK - sentiment, summary, embedding, translation, web search, scraping, vision, audio, and validation
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+<!-- AUTO-GENERATED: do not edit above this line. Run `tools/docgen.sh`. -->
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-jigsawstack
+```
+
+## Usage
+
+Register every JigsawStack tool at once with the `JigsawStack` helper:
+
+```php
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStack;
+
+$tools = JigsawStack::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackWebSearch;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSummary;
+
+$tools = [
+    new JigsawStackWebSearch,
+    new JigsawStackSummary,
+];
+```
+
+## Tools
+
+Each tool maps to a JigsawStack endpoint and returns the raw JSON response (pretty-printed) so the model can read every field.
+
+### General
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackSentiment` | `POST /v1/ai/sentiment` | `text` | — |
+| `JigsawStackSummary` | `POST /v1/ai/summary` | `text` | `type` (`text`\|`points`), `max_points` |
+| `JigsawStackEmbedding` | `POST /v1/embedding` | `text` | `type` (default `text`) |
+| `JigsawStackPrediction` | `POST /v1/ai/prediction` | `dataset` (JSON array of `{date,value}`) | `steps` |
+| `JigsawStackTextToSql` | `POST /v1/ai/sql` | `prompt` | `sql_schema`, `database` |
+
+### Translation
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackTranslateText` | `POST /v1/ai/translate` | `text`, `target_language` | `current_language` |
+| `JigsawStackTranslateImage` | `POST /v1/ai/translate/image` | `url`, `target_language` | — |
+
+### Web
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackWebSearch` | `POST /v1/web/search` | `query` | `ai_overview`, `safe_search`, `max_results` |
+| `JigsawStackAiScrape` | `POST /v1/ai/scrape` | `url`, `element_prompts` (comma-separated) | `root_element_selector` |
+| `JigsawStackHtmlToAny` | `POST /v1/web/html_to_any` | `html` | `type` (`png`\|`jpeg`\|`webp`\|`pdf`), `full_page` |
+| `JigsawStackSearchSuggestions` | `GET /v1/web/search/suggest` | `query` | — |
+
+### Vision
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackVocr` | `POST /v1/vocr` | `url` | `prompt` |
+| `JigsawStackObjectDetection` | `POST /v1/object_detection` | `url` | `prompts` (comma-separated), `annotated_image` |
+
+### Audio
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackSpeechToText` | `POST /v1/ai/transcribe` | `url` | `language`, `translate` |
+
+### Validation
+
+| Class | Endpoint | Required | Optional |
+|---|---|---|---|
+| `JigsawStackNsfwDetection` | `POST /v1/validate/nsfw` | `url` | — |
+| `JigsawStackProfanityCheck` | `POST /v1/validate/profanity` | `text` | `censor_replacement` |
+| `JigsawStackSpellCheck` | `POST /v1/validate/spell_check` | `text` | `language_code` |
+| `JigsawStackSpamCheck` | `POST /v1/validate/spam_check` | `text` | — |
+
+## Configuration
+
+Every tool reads its API key from Laravel's `services` config.
+
+### 1. Add the JigsawStack service to `config/services.php`
+
+```php
+// config/services.php
+
+return [
+
+    // ... existing services ...
+
+    'jigsawstack' => [
+        'key' => env('JIGSAWSTACK_API_KEY'),
+    ],
+
+];
+```
+
+### 2. Add the environment variable to `.env`
+
+```dotenv
+JIGSAWSTACK_API_KEY=your-key-here
+```
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `services.jigsawstack.key` | `JIGSAWSTACK_API_KEY` | - | **Required.** Your JigsawStack API key, sent as the `x-api-key` header. |
+
+## Safety
+
+- All tools validate required inputs before calling the API.
+- Requests time out after 60 seconds.
+- API errors and network failures are caught and returned as friendly string messages so the model can recover.
+- Requires a valid JigsawStack API key; tools return a clear "not configured" message when it is missing.
+
+## JigsawStack API
+
+These tools use the [JigsawStack API](https://jigsawstack.com/docs). See the [API reference](https://jigsawstack.com/docs/api-reference) for full details on each endpoint and its response shape.

--- a/src/JigsawStack/composer.json
+++ b/src/JigsawStack/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "shipfastlabs/toolkit-jigsawstack",
+    "description": "JigsawStack tools for the Laravel AI SDK - sentiment, summary, embedding, translation, web search, scraping, vision, audio, and validation",
+    "keywords": ["laravel", "ai", "tool", "jigsawstack", "sentiment", "summary", "embedding", "translate", "web-search", "scrape", "ocr", "speech-to-text"],
+    "license": "MIT",
+    "require": {
+        "php": "^8.4.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "laravel/ai": "^0.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\JigsawStack\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\JigsawStack\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/JigsawStack/src/Concerns/InteractsWithJigsawStack.php
+++ b/src/JigsawStack/src/Concerns/InteractsWithJigsawStack.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack\Concerns;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Tools\Request;
+use Throwable;
+
+trait InteractsWithJigsawStack
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function request(string $method, string $path, array $data): string
+    {
+        $apiKey = config('services.jigsawstack.key');
+
+        if (! is_string($apiKey) || $apiKey === '') {
+            return 'The JigsawStack tool is not configured. Set services.jigsawstack.key in your config/services.php file.';
+        }
+
+        $client = Http::timeout(60)->withHeaders(['x-api-key' => $apiKey]);
+        $url = 'https://api.jigsawstack.com/'.$path;
+
+        try {
+            $response = $method === 'get'
+                ? $client->get($url, $data)
+                : $client->post($url, $data);
+        } catch (Throwable $throwable) {
+            return sprintf('The JigsawStack request failed: %s', $throwable->getMessage());
+        }
+
+        if ($response->failed()) {
+            return sprintf(
+                'The JigsawStack request failed with status %d: %s',
+                $response->status(),
+                $response->body()
+            );
+        }
+
+        $decoded = $response->json();
+
+        if (! is_array($decoded)) {
+            return 'The JigsawStack response was invalid.';
+        }
+
+        return json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function withOptional(Request $request, array $payload, string ...$keys): array
+    {
+        foreach ($keys as $key) {
+            if ($request->filled($key)) {
+                $payload[$key] = $request[$key];
+            }
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function splitList(string $value): array
+    {
+        return str($value)
+            ->explode(',')
+            ->map(fn (string $item): string => trim($item))
+            ->filter(fn (string $item): bool => $item !== '')
+            ->values()
+            ->all();
+    }
+}

--- a/src/JigsawStack/src/JigsawStack.php
+++ b/src/JigsawStack/src/JigsawStack.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+
+class JigsawStack
+{
+    /**
+     * @return Collection<int, Tool>
+     */
+    public static function all(): Collection
+    {
+        return new Collection([
+            new JigsawStackSentiment,
+            new JigsawStackSummary,
+            new JigsawStackEmbedding,
+            new JigsawStackPrediction,
+            new JigsawStackTextToSql,
+            new JigsawStackTranslateText,
+            new JigsawStackTranslateImage,
+            new JigsawStackWebSearch,
+            new JigsawStackAiScrape,
+            new JigsawStackHtmlToAny,
+            new JigsawStackSearchSuggestions,
+            new JigsawStackVocr,
+            new JigsawStackObjectDetection,
+            new JigsawStackSpeechToText,
+            new JigsawStackNsfwDetection,
+            new JigsawStackProfanityCheck,
+            new JigsawStackSpellCheck,
+            new JigsawStackSpamCheck,
+        ]);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackAiScrape.php
+++ b/src/JigsawStack/src/JigsawStackAiScrape.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackAiScrape implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Extract structured data from a web page using JigsawStack AI scraping.
+            Describe the fields you want in plain language and the tool returns the
+            matching content from the page.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema
+                ->string()
+                ->description('The URL of the web page to scrape')
+                ->required(),
+            'element_prompts' => $schema
+                ->string()
+                ->description('A comma-separated list of plain-language descriptions of the data to extract (maximum 5)')
+                ->required(),
+            'root_element_selector' => $schema
+                ->string()
+                ->description("A CSS selector to scope scraping to part of the page (default: 'main')")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('url')) {
+            return 'The URL is empty. Provide a URL to scrape.';
+        }
+
+        if (! $request->filled('element_prompts')) {
+            return 'The element_prompts are empty. Describe what to scrape.';
+        }
+
+        $prompts = $this->splitList((string) $request->string('element_prompts'));
+
+        if (blank($prompts)) {
+            return 'No valid element prompts were provided.';
+        }
+
+        $payload = $this->withOptional($request, [
+            'url' => trim((string) $request->string('url')),
+            'element_prompts' => $prompts,
+        ], 'root_element_selector');
+
+        return $this->request('post', 'v1/ai/scrape', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackEmbedding.php
+++ b/src/JigsawStack/src/JigsawStackEmbedding.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackEmbedding implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Generate vector embeddings for text using JigsawStack. Use the
+            resulting vectors for semantic search, clustering, or retrieval.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'text' => $schema
+                ->string()
+                ->description('The text content to embed')
+                ->required(),
+            'type' => $schema
+                ->string()
+                ->description("The content type to embed - 'text' or 'text-other' (default: 'text')")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('text')) {
+            return 'The text is empty. Provide text to embed.';
+        }
+
+        $text = trim((string) $request->string('text'));
+        $type = $request->filled('type') ? (string) $request->string('type') : 'text';
+
+        return $this->request('post', 'v1/embedding', [
+            'type' => $type,
+            'text' => $text,
+        ]);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackHtmlToAny.php
+++ b/src/JigsawStack/src/JigsawStackHtmlToAny.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackHtmlToAny implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Render raw HTML into an image or PDF using JigsawStack. Returns a URL
+            to the generated file.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'html' => $schema
+                ->string()
+                ->description('The HTML markup to render')
+                ->required(),
+            'type' => $schema
+                ->string()
+                ->description("The output format - 'png', 'jpeg', 'webp', or 'pdf' (default: 'png')")
+                ->nullable()
+                ->required(),
+            'full_page' => $schema
+                ->boolean()
+                ->description('Whether to capture the entire scrollable page (default: false)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('html')) {
+            return 'The HTML is empty. Provide HTML markup to render.';
+        }
+
+        $html = trim((string) $request->string('html'));
+
+        $payload = $this->withOptional($request, [
+            'html' => $html,
+            'return_type' => 'url',
+        ], 'type', 'full_page');
+
+        return $this->request('post', 'v1/web/html_to_any', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackNsfwDetection.php
+++ b/src/JigsawStack/src/JigsawStackNsfwDetection.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackNsfwDetection implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Detect NSFW content, nudity, or gore in an image using JigsawStack.
+            Returns per-category flags and confidence scores.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema
+                ->string()
+                ->description('The URL of the image to analyze')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('url')) {
+            return 'The URL is empty. Provide an image URL to analyze.';
+        }
+
+        $url = trim((string) $request->string('url'));
+
+        return $this->request('post', 'v1/validate/nsfw', ['url' => $url]);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackObjectDetection.php
+++ b/src/JigsawStack/src/JigsawStackObjectDetection.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackObjectDetection implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Detect and locate objects within an image using JigsawStack.
+            Optionally provide prompts to target specific objects to find.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema
+                ->string()
+                ->description('The URL of the image to analyze')
+                ->required(),
+            'prompts' => $schema
+                ->string()
+                ->description('A comma-separated list of objects to detect. Detects all objects when omitted.')
+                ->nullable()
+                ->required(),
+            'annotated_image' => $schema
+                ->boolean()
+                ->description('Whether to return an annotated copy of the image (default: false)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('url')) {
+            return 'The URL is empty. Provide an image URL to analyze.';
+        }
+
+        $payload = ['url' => trim((string) $request->string('url'))];
+
+        if ($request->filled('prompts')) {
+            $prompts = $this->splitList((string) $request->string('prompts'));
+
+            if (filled($prompts)) {
+                $payload['prompts'] = $prompts;
+            }
+        }
+
+        $payload = $this->withOptional($request, $payload, 'annotated_image');
+
+        return $this->request('post', 'v1/object_detection', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackPrediction.php
+++ b/src/JigsawStack/src/JigsawStackPrediction.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use JsonException;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackPrediction implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Forecast future values from a time-series dataset using JigsawStack.
+            Provide at least five historical data points and the number of future
+            steps to predict.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'dataset' => $schema
+                ->string()
+                ->description('A JSON array of historical data points, each an object with a "date" (YYYY-MM-DD) and a "value" (number). Provide 5 to 1000 points.')
+                ->required(),
+            'steps' => $schema
+                ->integer()
+                ->description('The number of future predictions to generate (1-500, default: 5)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('dataset')) {
+            return 'The dataset is empty. Provide a JSON array of {"date","value"} points.';
+        }
+
+        try {
+            $dataset = json_decode(trim((string) $request->string('dataset')), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return 'The dataset must be valid JSON. Provide a JSON array of {"date","value"} points.';
+        }
+
+        if (! is_array($dataset)) {
+            return 'The dataset must be a JSON array of {"date","value"} points.';
+        }
+
+        $payload = $this->withOptional($request, ['dataset' => $dataset], 'steps');
+
+        return $this->request('post', 'v1/ai/prediction', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackProfanityCheck.php
+++ b/src/JigsawStack/src/JigsawStackProfanityCheck.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackProfanityCheck implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Detect and censor profanity in text using JigsawStack. Returns the
+            matched profanities and a cleaned version of the text.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'text' => $schema
+                ->string()
+                ->description('The text to check for profanity')
+                ->required(),
+            'censor_replacement' => $schema
+                ->string()
+                ->description("The character used to mask profanity (default: '*')")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('text')) {
+            return 'The text is empty. Provide text to check for profanity.';
+        }
+
+        $text = trim((string) $request->string('text'));
+
+        $payload = $this->withOptional($request, ['text' => $text], 'censor_replacement');
+
+        return $this->request('post', 'v1/validate/profanity', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackSearchSuggestions.php
+++ b/src/JigsawStack/src/JigsawStackSearchSuggestions.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackSearchSuggestions implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Get autocomplete search suggestions for a partial query using
+            JigsawStack. Useful for building type-ahead search experiences.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema
+                ->string()
+                ->description('The partial search query to get suggestions for (maximum 200 characters)')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('query')) {
+            return 'The query is empty. Provide a query to get suggestions for.';
+        }
+
+        $query = trim((string) $request->string('query'));
+
+        return $this->request('get', 'v1/web/search/suggest', ['query' => $query]);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackSentiment.php
+++ b/src/JigsawStack/src/JigsawStackSentiment.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackSentiment implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Analyze the emotional tone of text using JigsawStack. Returns the
+            overall sentiment (positive, negative, or neutral), the dominant
+            emotion, a confidence score, and a per-sentence breakdown.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'text' => $schema
+                ->string()
+                ->description('The text content to analyze for sentiment and emotion')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('text')) {
+            return 'The text is empty. Provide text to analyze.';
+        }
+
+        $text = trim((string) $request->string('text'));
+
+        return $this->request('post', 'v1/ai/sentiment', ['text' => $text]);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackSpamCheck.php
+++ b/src/JigsawStack/src/JigsawStackSpamCheck.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackSpamCheck implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Detect whether text is spam using JigsawStack. Returns a spam flag
+            and a confidence score.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'text' => $schema
+                ->string()
+                ->description('The text to check for spam')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('text')) {
+            return 'The text is empty. Provide text to check for spam.';
+        }
+
+        $text = trim((string) $request->string('text'));
+
+        return $this->request('post', 'v1/validate/spam_check', ['text' => $text]);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackSpeechToText.php
+++ b/src/JigsawStack/src/JigsawStackSpeechToText.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackSpeechToText implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Transcribe spoken audio or video into text using JigsawStack.
+            Optionally translate the transcription into English.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema
+                ->string()
+                ->description('The URL of the audio or video file to transcribe')
+                ->required(),
+            'language' => $schema
+                ->string()
+                ->description("The language code of the audio, or 'auto' to detect it (default: 'auto')")
+                ->nullable()
+                ->required(),
+            'translate' => $schema
+                ->boolean()
+                ->description('Whether to translate the transcription into English (default: false)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('url')) {
+            return 'The URL is empty. Provide an audio or video URL to transcribe.';
+        }
+
+        $url = trim((string) $request->string('url'));
+
+        $payload = $this->withOptional($request, ['url' => $url], 'language', 'translate');
+
+        return $this->request('post', 'v1/ai/transcribe', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackSpellCheck.php
+++ b/src/JigsawStack/src/JigsawStackSpellCheck.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackSpellCheck implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Detect and correct spelling mistakes in text using JigsawStack.
+            Returns the misspelled words and an auto-corrected version of the text.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'text' => $schema
+                ->string()
+                ->description('The text to check for spelling mistakes')
+                ->required(),
+            'language_code' => $schema
+                ->string()
+                ->description("The language code of the text (default: 'en')")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('text')) {
+            return 'The text is empty. Provide text to spell-check.';
+        }
+
+        $text = trim((string) $request->string('text'));
+
+        $payload = $this->withOptional($request, ['text' => $text], 'language_code');
+
+        return $this->request('post', 'v1/validate/spell_check', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackSummary.php
+++ b/src/JigsawStack/src/JigsawStackSummary.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackSummary implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Summarize long text into a concise paragraph or bullet points using
+            JigsawStack. Use this to condense articles, documents, or transcripts.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'text' => $schema
+                ->string()
+                ->description('The text to summarize (maximum 300,000 characters)')
+                ->required(),
+            'type' => $schema
+                ->string()
+                ->description("Output format - 'text' for a paragraph or 'points' for bullet points (default: 'text')")
+                ->nullable()
+                ->required(),
+            'max_points' => $schema
+                ->integer()
+                ->description("Maximum number of bullet points when type is 'points' (1-100, default: 2)")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('text')) {
+            return 'The text is empty. Provide text to summarize.';
+        }
+
+        $text = trim((string) $request->string('text'));
+
+        $payload = $this->withOptional($request, ['text' => $text], 'type', 'max_points');
+
+        return $this->request('post', 'v1/ai/summary', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackTextToSql.php
+++ b/src/JigsawStack/src/JigsawStackTextToSql.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackTextToSql implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Convert a natural-language question into an SQL query using
+            JigsawStack. Provide the database schema so the generated query
+            references the correct tables and columns.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'prompt' => $schema
+                ->string()
+                ->description('The natural-language question to convert into SQL (minimum 10 characters)')
+                ->required(),
+            'sql_schema' => $schema
+                ->string()
+                ->description('The database schema (CREATE TABLE statements) the query should run against')
+                ->nullable()
+                ->required(),
+            'database' => $schema
+                ->string()
+                ->description("The target database for improved accuracy - 'postgresql', 'mysql', or 'sqlite'")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('prompt')) {
+            return 'The prompt is empty. Provide a question to convert into SQL.';
+        }
+
+        $prompt = trim((string) $request->string('prompt'));
+
+        $payload = $this->withOptional($request, ['prompt' => $prompt], 'sql_schema', 'database');
+
+        return $this->request('post', 'v1/ai/sql', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackTranslateImage.php
+++ b/src/JigsawStack/src/JigsawStackTranslateImage.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackTranslateImage implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Extract and translate the text found in an image using JigsawStack.
+            Returns a URL to the translated image.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema
+                ->string()
+                ->description('The URL of the image to translate')
+                ->required(),
+            'target_language' => $schema
+                ->string()
+                ->description('The language code to translate the image text into, e.g. "es", "fr", "de"')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('url')) {
+            return 'The URL is empty. Provide an image URL to translate.';
+        }
+
+        if (! $request->filled('target_language')) {
+            return 'The target_language is empty. Provide a language code to translate into.';
+        }
+
+        return $this->request('post', 'v1/ai/translate/image', [
+            'url' => trim((string) $request->string('url')),
+            'target_language' => trim((string) $request->string('target_language')),
+            'return_type' => 'url',
+        ]);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackTranslateText.php
+++ b/src/JigsawStack/src/JigsawStackTranslateText.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackTranslateText implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Translate text from one language to another using JigsawStack. The
+            source language is auto-detected when not provided.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'text' => $schema
+                ->string()
+                ->description('The text to translate (maximum 5000 characters)')
+                ->required(),
+            'target_language' => $schema
+                ->string()
+                ->description('The language code to translate into, e.g. "es", "fr", "de"')
+                ->required(),
+            'current_language' => $schema
+                ->string()
+                ->description('The language code of the source text. Auto-detected when omitted.')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('text')) {
+            return 'The text is empty. Provide text to translate.';
+        }
+
+        if (! $request->filled('target_language')) {
+            return 'The target_language is empty. Provide a language code to translate into.';
+        }
+
+        $payload = $this->withOptional($request, [
+            'text' => trim((string) $request->string('text')),
+            'target_language' => trim((string) $request->string('target_language')),
+        ], 'current_language');
+
+        return $this->request('post', 'v1/ai/translate', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackVocr.php
+++ b/src/JigsawStack/src/JigsawStackVocr.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackVocr implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Run vision OCR on an image or PDF using JigsawStack to read and
+            describe its contents. Optionally pass a prompt to extract specific
+            fields.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema
+                ->string()
+                ->description('The URL of the image or PDF to read')
+                ->required(),
+            'prompt' => $schema
+                ->string()
+                ->description("What to extract or how to analyze the image (default: 'Describe the image in detail.')")
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('url')) {
+            return 'The URL is empty. Provide an image or PDF URL to read.';
+        }
+
+        $url = trim((string) $request->string('url'));
+
+        $payload = $this->withOptional($request, ['url' => $url], 'prompt');
+
+        return $this->request('post', 'v1/vocr', $payload);
+    }
+}

--- a/src/JigsawStack/src/JigsawStackWebSearch.php
+++ b/src/JigsawStack/src/JigsawStackWebSearch.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\JigsawStack;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\Concerns\InteractsWithJigsawStack;
+
+#[Strict]
+class JigsawStackWebSearch implements Tool
+{
+    use InteractsWithJigsawStack;
+
+    public function description(): string
+    {
+        return <<<'TEXT'
+            Search the web for real-time information using JigsawStack. Returns
+            ranked results with an optional AI-generated overview of the answer.
+            TEXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema
+                ->string()
+                ->description('The search query to look up on the web (maximum 400 characters)')
+                ->required(),
+            'ai_overview' => $schema
+                ->boolean()
+                ->description('Whether to include an AI-generated overview of the results (default: true)')
+                ->nullable()
+                ->required(),
+            'safe_search' => $schema
+                ->string()
+                ->description("Safe-search level - 'moderate', 'strict', or 'off' (default: 'moderate')")
+                ->nullable()
+                ->required(),
+            'max_results' => $schema
+                ->integer()
+                ->description('Maximum number of results to return')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        if (! $request->filled('query')) {
+            return 'The search query is empty. Provide a query to search for.';
+        }
+
+        $query = trim((string) $request->string('query'));
+
+        $payload = $this->withOptional($request, ['query' => $query], 'ai_overview', 'safe_search', 'max_results');
+
+        return $this->request('post', 'v1/web/search', $payload);
+    }
+}

--- a/src/JigsawStack/tests/JigsawStackAiScrapeTest.php
+++ b/src/JigsawStack/tests/JigsawStackAiScrapeTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackAiScrape;
+
+it('has a description', function (): void {
+    expect((new JigsawStackAiScrape)->description())->toContain('scraping');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackAiScrape))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackAiScrape)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('url')
+        ->and($schema)->toHaveKey('element_prompts')
+        ->and($schema)->toHaveKey('root_element_selector');
+});
+
+it('returns an error when the url is empty', function (): void {
+    expect((new JigsawStackAiScrape)->handle(new Request(['url' => ' ', 'element_prompts' => 'price'])))
+        ->toContain('URL is empty');
+});
+
+it('returns an error when the element prompts are empty', function (): void {
+    expect((new JigsawStackAiScrape)->handle(new Request(['url' => 'https://x.test', 'element_prompts' => ' '])))
+        ->toContain('element_prompts are empty');
+});
+
+it('returns an error when no valid element prompts remain', function (): void {
+    expect((new JigsawStackAiScrape)->handle(new Request(['url' => 'https://x.test', 'element_prompts' => ',,'])))
+        ->toContain('No valid element prompts');
+});
+
+it('splits element prompts and forwards them', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'data' => []])]);
+
+    $result = (new JigsawStackAiScrape)->handle(new Request([
+        'url' => 'https://x.test',
+        'element_prompts' => 'product name, price',
+        'root_element_selector' => '#content',
+    ]));
+
+    expect($result)->toContain('success');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/ai/scrape')
+            ->and($request->data())->toMatchArray([
+                'url' => 'https://x.test',
+                'element_prompts' => ['product name', 'price'],
+                'root_element_selector' => '#content',
+            ]);
+
+        return true;
+    });
+});
+
+it('preserves a falsy "0" prompt token', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'data' => []])]);
+
+    (new JigsawStackAiScrape)->handle(new Request([
+        'url' => 'https://x.test',
+        'element_prompts' => '0, price',
+    ]));
+
+    Http::assertSent(function ($request): true {
+        expect($request->data())->toMatchArray(['element_prompts' => ['0', 'price']]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackEmbeddingTest.php
+++ b/src/JigsawStack/tests/JigsawStackEmbeddingTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackEmbedding;
+
+it('has a description', function (): void {
+    expect((new JigsawStackEmbedding)->description())->toContain('embeddings');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackEmbedding))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackEmbedding)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('text')->and($schema)->toHaveKey('type');
+});
+
+it('returns an error when the text is empty', function (): void {
+    expect((new JigsawStackEmbedding)->handle(new Request(['text' => ''])))->toContain('empty');
+});
+
+it('defaults the type to text', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'embeddings' => [[0.1, 0.2]]])]);
+
+    (new JigsawStackEmbedding)->handle(new Request(['text' => 'hello world']));
+
+    Http::assertSent(function ($request): true {
+        expect($request->data())->toBe(['type' => 'text', 'text' => 'hello world']);
+
+        return true;
+    });
+});
+
+it('accepts a custom type', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'embeddings' => []])]);
+
+    (new JigsawStackEmbedding)->handle(new Request(['text' => 'hello', 'type' => 'text-other']));
+
+    Http::assertSent(function ($request): true {
+        expect($request->data())->toHaveKey('type', 'text-other');
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackHtmlToAnyTest.php
+++ b/src/JigsawStack/tests/JigsawStackHtmlToAnyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackHtmlToAny;
+
+it('has a description', function (): void {
+    expect((new JigsawStackHtmlToAny)->description())->toContain('image or PDF');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackHtmlToAny))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackHtmlToAny)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('html')
+        ->and($schema)->toHaveKey('type')
+        ->and($schema)->toHaveKey('full_page');
+});
+
+it('returns an error when the html is empty', function (): void {
+    expect((new JigsawStackHtmlToAny)->handle(new Request(['html' => ' '])))->toContain('empty');
+});
+
+it('renders html on success', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'url' => 'https://x.test/out.pdf'])]);
+
+    $result = (new JigsawStackHtmlToAny)->handle(new Request([
+        'html' => '<h1>Hi</h1>',
+        'type' => 'pdf',
+        'full_page' => true,
+    ]));
+
+    expect($result)->toContain('out.pdf');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/web/html_to_any')
+            ->and($request->data())->toMatchArray([
+                'html' => '<h1>Hi</h1>',
+                'return_type' => 'url',
+                'type' => 'pdf',
+                'full_page' => true,
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackNsfwDetectionTest.php
+++ b/src/JigsawStack/tests/JigsawStackNsfwDetectionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackNsfwDetection;
+
+it('has a description', function (): void {
+    expect((new JigsawStackNsfwDetection)->description())->toContain('NSFW');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackNsfwDetection))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackNsfwDetection)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('url');
+});
+
+it('returns an error when the url is empty', function (): void {
+    expect((new JigsawStackNsfwDetection)->handle(new Request(['url' => ' '])))->toContain('empty');
+});
+
+it('analyzes an image on success', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'nsfw' => false, 'nsfw_score' => 0.01])]);
+
+    $result = (new JigsawStackNsfwDetection)->handle(new Request(['url' => 'https://x.test/a.png']));
+
+    expect($result)->toContain('nsfw_score');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/validate/nsfw')
+            ->and($request->data())->toBe(['url' => 'https://x.test/a.png']);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackObjectDetectionTest.php
+++ b/src/JigsawStack/tests/JigsawStackObjectDetectionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackObjectDetection;
+
+it('has a description', function (): void {
+    expect((new JigsawStackObjectDetection)->description())->toContain('Detect');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackObjectDetection))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackObjectDetection)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('url')
+        ->and($schema)->toHaveKey('prompts')
+        ->and($schema)->toHaveKey('annotated_image');
+});
+
+it('returns an error when the url is empty', function (): void {
+    expect((new JigsawStackObjectDetection)->handle(new Request(['url' => ' '])))->toContain('empty');
+});
+
+it('detects all objects when no prompts are given', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'objects' => []])]);
+
+    (new JigsawStackObjectDetection)->handle(new Request(['url' => 'https://x.test/a.png']));
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/object_detection')
+            ->and($request->data())->toBe(['url' => 'https://x.test/a.png']);
+
+        return true;
+    });
+});
+
+it('splits prompts and forwards optional flags', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'objects' => [['label' => 'cat']]])]);
+
+    $result = (new JigsawStackObjectDetection)->handle(new Request([
+        'url' => 'https://x.test/a.png',
+        'prompts' => 'cat, dog',
+        'annotated_image' => true,
+    ]));
+
+    expect($result)->toContain('cat');
+
+    Http::assertSent(function ($request): true {
+        expect($request->data())->toMatchArray([
+            'url' => 'https://x.test/a.png',
+            'prompts' => ['cat', 'dog'],
+            'annotated_image' => true,
+        ]);
+
+        return true;
+    });
+});
+
+it('omits prompts when the list collapses to empty', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'objects' => []])]);
+
+    (new JigsawStackObjectDetection)->handle(new Request([
+        'url' => 'https://x.test/a.png',
+        'prompts' => ' , ',
+    ]));
+
+    Http::assertSent(function ($request): true {
+        expect($request->data())->toBe(['url' => 'https://x.test/a.png']);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackPredictionTest.php
+++ b/src/JigsawStack/tests/JigsawStackPredictionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackPrediction;
+
+it('has a description', function (): void {
+    expect((new JigsawStackPrediction)->description())->toContain('Forecast');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackPrediction))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackPrediction)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('dataset')->and($schema)->toHaveKey('steps');
+});
+
+it('returns an error when the dataset is empty', function (): void {
+    expect((new JigsawStackPrediction)->handle(new Request(['dataset' => ' '])))->toContain('empty');
+});
+
+it('returns an error when the dataset is not valid json', function (): void {
+    expect((new JigsawStackPrediction)->handle(new Request(['dataset' => '{not json'])))
+        ->toContain('valid JSON');
+});
+
+it('returns an error when the dataset is not a json array', function (): void {
+    expect((new JigsawStackPrediction)->handle(new Request(['dataset' => '42'])))
+        ->toContain('JSON array');
+});
+
+it('forwards a decoded dataset and steps', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'prediction' => []])]);
+
+    $result = (new JigsawStackPrediction)->handle(new Request([
+        'dataset' => '[{"date":"2024-01-01","value":10}]',
+        'steps' => 3,
+    ]));
+
+    expect($result)->toContain('success');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/ai/prediction')
+            ->and($request->data())->toMatchArray([
+                'dataset' => [['date' => '2024-01-01', 'value' => 10]],
+                'steps' => 3,
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackProfanityCheckTest.php
+++ b/src/JigsawStack/tests/JigsawStackProfanityCheckTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackProfanityCheck;
+
+it('has a description', function (): void {
+    expect((new JigsawStackProfanityCheck)->description())->toContain('profanity');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackProfanityCheck))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackProfanityCheck)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('text')->and($schema)->toHaveKey('censor_replacement');
+});
+
+it('returns an error when the text is empty', function (): void {
+    expect((new JigsawStackProfanityCheck)->handle(new Request(['text' => ' '])))->toContain('empty');
+});
+
+it('checks text with a custom censor replacement', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'profanities_found' => 0])]);
+
+    $result = (new JigsawStackProfanityCheck)->handle(new Request([
+        'text' => 'some text',
+        'censor_replacement' => '#',
+    ]));
+
+    expect($result)->toContain('profanities_found');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/validate/profanity')
+            ->and($request->data())->toMatchArray([
+                'text' => 'some text',
+                'censor_replacement' => '#',
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackSearchSuggestionsTest.php
+++ b/src/JigsawStack/tests/JigsawStackSearchSuggestionsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSearchSuggestions;
+
+it('has a description', function (): void {
+    expect((new JigsawStackSearchSuggestions)->description())->toContain('autocomplete');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackSearchSuggestions))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackSearchSuggestions)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('query');
+});
+
+it('returns an error when the query is empty', function (): void {
+    expect((new JigsawStackSearchSuggestions)->handle(new Request(['query' => ' '])))->toContain('empty');
+});
+
+it('sends a GET request with the query string', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'suggestions' => ['laravel', 'laravel news']])]);
+
+    $result = (new JigsawStackSearchSuggestions)->handle(new Request(['query' => 'lara']));
+
+    expect($result)->toContain('laravel news');
+
+    Http::assertSent(function ($request): true {
+        expect($request->method())->toBe('GET')
+            ->and($request->url())->toBe('https://api.jigsawstack.com/v1/web/search/suggest?query=lara');
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackSentimentTest.php
+++ b/src/JigsawStack/tests/JigsawStackSentimentTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSentiment;
+
+it('has a description', function (): void {
+    expect((new JigsawStackSentiment)->description())->toContain('emotional tone');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackSentiment))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackSentiment)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('text');
+});
+
+it('returns an error when the text is empty', function (): void {
+    $result = (new JigsawStackSentiment)->handle(new Request(['text' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.jigsawstack.key');
+
+    $result = (new JigsawStackSentiment)->handle(new Request(['text' => 'I love this']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('sends the api key as the x-api-key header', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'sentiment' => ['sentiment' => 'positive']])]);
+
+    (new JigsawStackSentiment)->handle(new Request(['text' => 'I love this']));
+
+    Http::assertSent(function ($request): true {
+        expect($request->hasHeader('x-api-key', 'test-key'))->toBeTrue();
+
+        return true;
+    });
+});
+
+it('returns sentiment results on success', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake([
+        'https://api.jigsawstack.com/v1/ai/sentiment' => Http::response([
+            'success' => true,
+            'sentiment' => ['sentiment' => 'positive', 'emotion' => 'joy', 'score' => 0.9],
+        ]),
+    ]);
+
+    $result = (new JigsawStackSentiment)->handle(new Request(['text' => 'I love this']));
+
+    expect($result)->toContain('positive')->and($result)->toContain('joy');
+});
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake([
+        'https://api.jigsawstack.com/v1/ai/sentiment' => Http::response('Invalid API key', 401),
+    ]);
+
+    $result = (new JigsawStackSentiment)->handle(new Request(['text' => 'I love this']));
+
+    expect($result)->toContain('failed with status 401');
+});
+
+it('returns an error when the request throws', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(fn () => throw new ConnectionException('Connection timed out'));
+
+    $result = (new JigsawStackSentiment)->handle(new Request(['text' => 'I love this']));
+
+    expect($result)->toContain('The JigsawStack request failed')
+        ->and($result)->toContain('Connection timed out');
+});
+
+it('returns an error when the response is not valid json', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake([
+        'https://api.jigsawstack.com/v1/ai/sentiment' => Http::response('not json', 200),
+    ]);
+
+    $result = (new JigsawStackSentiment)->handle(new Request(['text' => 'I love this']));
+
+    expect($result)->toContain('response was invalid');
+});

--- a/src/JigsawStack/tests/JigsawStackSpamCheckTest.php
+++ b/src/JigsawStack/tests/JigsawStackSpamCheckTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSpamCheck;
+
+it('has a description', function (): void {
+    expect((new JigsawStackSpamCheck)->description())->toContain('spam');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackSpamCheck))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackSpamCheck)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('text');
+});
+
+it('returns an error when the text is empty', function (): void {
+    expect((new JigsawStackSpamCheck)->handle(new Request(['text' => ' '])))->toContain('empty');
+});
+
+it('checks text for spam on success', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'check' => ['is_spam' => true, 'score' => 0.98]])]);
+
+    $result = (new JigsawStackSpamCheck)->handle(new Request(['text' => 'Win a free prize now!']));
+
+    expect($result)->toContain('is_spam');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/validate/spam_check')
+            ->and($request->data())->toBe(['text' => 'Win a free prize now!']);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackSpeechToTextTest.php
+++ b/src/JigsawStack/tests/JigsawStackSpeechToTextTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSpeechToText;
+
+it('has a description', function (): void {
+    expect((new JigsawStackSpeechToText)->description())->toContain('Transcribe');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackSpeechToText))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackSpeechToText)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('url')
+        ->and($schema)->toHaveKey('language')
+        ->and($schema)->toHaveKey('translate');
+});
+
+it('returns an error when the url is empty', function (): void {
+    expect((new JigsawStackSpeechToText)->handle(new Request(['url' => ' '])))->toContain('empty');
+});
+
+it('transcribes audio with optional parameters', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'text' => 'Bonjour'])]);
+
+    $result = (new JigsawStackSpeechToText)->handle(new Request([
+        'url' => 'https://x.test/a.mp3',
+        'language' => 'fr',
+        'translate' => true,
+    ]));
+
+    expect($result)->toContain('Bonjour');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/ai/transcribe')
+            ->and($request->data())->toMatchArray([
+                'url' => 'https://x.test/a.mp3',
+                'language' => 'fr',
+                'translate' => true,
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackSpellCheckTest.php
+++ b/src/JigsawStack/tests/JigsawStackSpellCheckTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSpellCheck;
+
+it('has a description', function (): void {
+    expect((new JigsawStackSpellCheck)->description())->toContain('spelling');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackSpellCheck))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackSpellCheck)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('text')->and($schema)->toHaveKey('language_code');
+});
+
+it('returns an error when the text is empty', function (): void {
+    expect((new JigsawStackSpellCheck)->handle(new Request(['text' => ' '])))->toContain('empty');
+});
+
+it('checks spelling with an optional language code', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'auto_correct_text' => 'hello world'])]);
+
+    $result = (new JigsawStackSpellCheck)->handle(new Request([
+        'text' => 'helllo wrld',
+        'language_code' => 'en',
+    ]));
+
+    expect($result)->toContain('hello world');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/validate/spell_check')
+            ->and($request->data())->toMatchArray([
+                'text' => 'helllo wrld',
+                'language_code' => 'en',
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackSummaryTest.php
+++ b/src/JigsawStack/tests/JigsawStackSummaryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSummary;
+
+it('has a description', function (): void {
+    expect((new JigsawStackSummary)->description())->toContain('Summarize');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackSummary))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackSummary)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('text')
+        ->and($schema)->toHaveKey('type')
+        ->and($schema)->toHaveKey('max_points');
+});
+
+it('returns an error when the text is empty', function (): void {
+    expect((new JigsawStackSummary)->handle(new Request(['text' => ' '])))->toContain('empty');
+});
+
+it('forwards optional parameters when provided', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'summary' => ['point one']])]);
+
+    $result = (new JigsawStackSummary)->handle(new Request([
+        'text' => 'A long article.',
+        'type' => 'points',
+        'max_points' => 5,
+    ]));
+
+    expect($result)->toContain('point one');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/ai/summary')
+            ->and($request->data())->toMatchArray([
+                'text' => 'A long article.',
+                'type' => 'points',
+                'max_points' => 5,
+            ]);
+
+        return true;
+    });
+});
+
+it('omits optional parameters when null', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'summary' => 'A summary.'])]);
+
+    (new JigsawStackSummary)->handle(new Request([
+        'text' => 'A long article.',
+        'type' => null,
+        'max_points' => null,
+    ]));
+
+    Http::assertSent(function ($request): true {
+        expect($request->data())->toBe(['text' => 'A long article.']);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackTest.php
+++ b/src/JigsawStack/tests/JigsawStackTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStack;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackAiScrape;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackEmbedding;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackHtmlToAny;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackNsfwDetection;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackObjectDetection;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackPrediction;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackProfanityCheck;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSearchSuggestions;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSentiment;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSpamCheck;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSpeechToText;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSpellCheck;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSummary;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackTextToSql;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackTranslateImage;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackTranslateText;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackVocr;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackWebSearch;
+
+it('creates a collection of all JigsawStack tools', function (): void {
+    $tools = JigsawStack::all();
+
+    expect($tools)->toBeInstanceOf(Collection::class)
+        ->and($tools)->toHaveCount(18)
+        ->and($tools->all())->toContainOnlyInstancesOf(Tool::class);
+});
+
+it('includes each JigsawStack tool exactly once', function (): void {
+    $classes = JigsawStack::all()->map(fn ($tool): string => $tool::class);
+
+    expect($classes->all())->toEqualCanonicalizing([
+        JigsawStackSentiment::class,
+        JigsawStackSummary::class,
+        JigsawStackEmbedding::class,
+        JigsawStackPrediction::class,
+        JigsawStackTextToSql::class,
+        JigsawStackTranslateText::class,
+        JigsawStackTranslateImage::class,
+        JigsawStackWebSearch::class,
+        JigsawStackAiScrape::class,
+        JigsawStackHtmlToAny::class,
+        JigsawStackSearchSuggestions::class,
+        JigsawStackVocr::class,
+        JigsawStackObjectDetection::class,
+        JigsawStackSpeechToText::class,
+        JigsawStackNsfwDetection::class,
+        JigsawStackProfanityCheck::class,
+        JigsawStackSpellCheck::class,
+        JigsawStackSpamCheck::class,
+    ]);
+});

--- a/src/JigsawStack/tests/JigsawStackTextToSqlTest.php
+++ b/src/JigsawStack/tests/JigsawStackTextToSqlTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackTextToSql;
+
+it('has a description', function (): void {
+    expect((new JigsawStackTextToSql)->description())->toContain('SQL');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackTextToSql))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackTextToSql)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('prompt')
+        ->and($schema)->toHaveKey('sql_schema')
+        ->and($schema)->toHaveKey('database');
+});
+
+it('returns an error when the prompt is empty', function (): void {
+    expect((new JigsawStackTextToSql)->handle(new Request(['prompt' => ' '])))->toContain('empty');
+});
+
+it('forwards the prompt, schema and database', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'sql' => 'SELECT count(*) FROM users'])]);
+
+    $result = (new JigsawStackTextToSql)->handle(new Request([
+        'prompt' => 'How many users signed up today?',
+        'sql_schema' => 'CREATE TABLE users (id int)',
+        'database' => 'postgresql',
+    ]));
+
+    expect($result)->toContain('SELECT');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/ai/sql')
+            ->and($request->data())->toMatchArray([
+                'prompt' => 'How many users signed up today?',
+                'sql_schema' => 'CREATE TABLE users (id int)',
+                'database' => 'postgresql',
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackTranslateImageTest.php
+++ b/src/JigsawStack/tests/JigsawStackTranslateImageTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackTranslateImage;
+
+it('has a description', function (): void {
+    expect((new JigsawStackTranslateImage)->description())->toContain('translate');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackTranslateImage))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackTranslateImage)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('url')->and($schema)->toHaveKey('target_language');
+});
+
+it('returns an error when the url is empty', function (): void {
+    expect((new JigsawStackTranslateImage)->handle(new Request(['url' => ' ', 'target_language' => 'es'])))
+        ->toContain('empty');
+});
+
+it('returns an error when the target language is empty', function (): void {
+    expect((new JigsawStackTranslateImage)->handle(new Request(['url' => 'https://x.test/a.png', 'target_language' => ' '])))
+        ->toContain('target_language');
+});
+
+it('translates an image on success', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'url' => 'https://x.test/translated.png'])]);
+
+    $result = (new JigsawStackTranslateImage)->handle(new Request([
+        'url' => 'https://x.test/a.png',
+        'target_language' => 'es',
+    ]));
+
+    expect($result)->toContain('translated.png');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/ai/translate/image')
+            ->and($request->data())->toMatchArray([
+                'url' => 'https://x.test/a.png',
+                'target_language' => 'es',
+                'return_type' => 'url',
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackTranslateTextTest.php
+++ b/src/JigsawStack/tests/JigsawStackTranslateTextTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackTranslateText;
+
+it('has a description', function (): void {
+    expect((new JigsawStackTranslateText)->description())->toContain('Translate text');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackTranslateText))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackTranslateText)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('text')
+        ->and($schema)->toHaveKey('target_language')
+        ->and($schema)->toHaveKey('current_language');
+});
+
+it('returns an error when the text is empty', function (): void {
+    expect((new JigsawStackTranslateText)->handle(new Request(['text' => ' ', 'target_language' => 'es'])))
+        ->toContain('empty');
+});
+
+it('returns an error when the target language is empty', function (): void {
+    expect((new JigsawStackTranslateText)->handle(new Request(['text' => 'Hello', 'target_language' => ' '])))
+        ->toContain('target_language');
+});
+
+it('translates text on success', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'translated_text' => 'Hola'])]);
+
+    $result = (new JigsawStackTranslateText)->handle(new Request([
+        'text' => 'Hello',
+        'target_language' => 'es',
+        'current_language' => 'en',
+    ]));
+
+    expect($result)->toContain('Hola');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/ai/translate')
+            ->and($request->data())->toMatchArray([
+                'text' => 'Hello',
+                'target_language' => 'es',
+                'current_language' => 'en',
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackVocrTest.php
+++ b/src/JigsawStack/tests/JigsawStackVocrTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackVocr;
+
+it('has a description', function (): void {
+    expect((new JigsawStackVocr)->description())->toContain('OCR');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackVocr))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackVocr)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('url')->and($schema)->toHaveKey('prompt');
+});
+
+it('returns an error when the url is empty', function (): void {
+    expect((new JigsawStackVocr)->handle(new Request(['url' => ' '])))->toContain('empty');
+});
+
+it('reads an image with an optional prompt', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'context' => 'Total: $9.99'])]);
+
+    $result = (new JigsawStackVocr)->handle(new Request([
+        'url' => 'https://x.test/a.png',
+        'prompt' => 'Read the receipt total',
+    ]));
+
+    expect($result)->toContain('9.99');
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/vocr')
+            ->and($request->data())->toMatchArray([
+                'url' => 'https://x.test/a.png',
+                'prompt' => 'Read the receipt total',
+            ]);
+
+        return true;
+    });
+});

--- a/src/JigsawStack/tests/JigsawStackWebSearchTest.php
+++ b/src/JigsawStack/tests/JigsawStackWebSearchTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStackWebSearch;
+
+it('has a description', function (): void {
+    expect((new JigsawStackWebSearch)->description())->toContain('Search the web');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new JigsawStackWebSearch))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new JigsawStackWebSearch)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('query')
+        ->and($schema)->toHaveKey('ai_overview')
+        ->and($schema)->toHaveKey('safe_search')
+        ->and($schema)->toHaveKey('max_results');
+});
+
+it('returns an error when the query is empty', function (): void {
+    expect((new JigsawStackWebSearch)->handle(new Request(['query' => ' '])))->toContain('empty');
+});
+
+it('forwards optional parameters when provided', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'results' => []])]);
+
+    (new JigsawStackWebSearch)->handle(new Request([
+        'query' => 'laravel news',
+        'ai_overview' => false,
+        'safe_search' => 'strict',
+        'max_results' => 5,
+    ]));
+
+    Http::assertSent(function ($request): true {
+        expect($request->url())->toBe('https://api.jigsawstack.com/v1/web/search')
+            ->and($request->data())->toMatchArray([
+                'query' => 'laravel news',
+                'ai_overview' => false,
+                'safe_search' => 'strict',
+                'max_results' => 5,
+            ]);
+
+        return true;
+    });
+});
+
+it('searches with only a query', function (): void {
+    config()->set('services.jigsawstack.key', 'test-key');
+
+    Http::fake(['*' => Http::response(['success' => true, 'results' => [['title' => 'Laravel']]])]);
+
+    $result = (new JigsawStackWebSearch)->handle(new Request(['query' => 'laravel news']));
+
+    expect($result)->toContain('Laravel');
+
+    Http::assertSent(function ($request): true {
+        expect($request->data())->toBe(['query' => 'laravel news']);
+
+        return true;
+    });
+});

--- a/workbench/app/Ai/Agents/ToolkitAgent.php
+++ b/workbench/app/Ai/Agents/ToolkitAgent.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Promptable;
 use Shipfastlabs\Toolkit\Calculator\CalculatorTool;
 use Shipfastlabs\Toolkit\Database\DatabaseQueryTool;
+use Shipfastlabs\Toolkit\JigsawStack\JigsawStack;
 use Shipfastlabs\Toolkit\Tavily\Tavily;
 
 /**
@@ -37,6 +38,7 @@ class ToolkitAgent implements Agent, HasTools
             new CalculatorTool,
             new DatabaseQueryTool,
             ...Tavily::all(),
+            ...JigsawStack::all(),
         ];
     }
 }

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -20,6 +20,7 @@ class WorkbenchServiceProvider extends ServiceProvider
 
         config([
             'services.tavily.key' => env('TAVILY_API_KEY'),
+            'services.jigsawstack.key' => env('JIGSAWSTACK_API_KEY'),
             'ai.providers.openai.key' => env('OPENAI_API_KEY'),
         ]);
     }

--- a/workbench/storage
+++ b/workbench/storage
@@ -1,0 +1,1 @@
+/Users/pushpakchhajed/Work/Projects/worktrees/toolkit/nimble-drum/toolkit/vendor/orchestra/testbench-core/laravel/storage

--- a/workbench/storage
+++ b/workbench/storage
@@ -1,1 +1,0 @@
-/Users/pushpakchhajed/Work/Projects/worktrees/toolkit/nimble-drum/toolkit/vendor/orchestra/testbench-core/laravel/storage


### PR DESCRIPTION
Currently the toolkit covers web search via Tavily, but there's no integration for JigsawStack's AI APIs. This adds a single `shipfastlabs/toolkit-jigsawstack` package exposing all 18 tools from JigsawStack's AI SDK integration (sentiment, summary, embedding, prediction, text-to-SQL, text/image translation, web search, AI scrape, HTML-to-any, search suggestions, vOCR, object detection, speech-to-text, and the NSFW/profanity/spell/spam validators).

Register them the same way as Tavily:

```php
use Shipfastlabs\Toolkit\JigsawStack\JigsawStack;

$tools = JigsawStack::all(); // Collection<int, Tool>
```

or pick individual ones:

```php
use Shipfastlabs\Toolkit\JigsawStack\JigsawStackWebSearch;
use Shipfastlabs\Toolkit\JigsawStack\JigsawStackSentiment;

$tools = [new JigsawStackWebSearch, new JigsawStackSentiment];
```

### Notes

- Structure mirrors the Tavily package: one mirror, a `JigsawStack::all()` helper, and a shared `InteractsWithJigsawStack` trait for the HTTP call and error handling so each tool stays tiny.
- API key is read from `config('services.jigsawstack.key')` (sent as the `x-api-key` header), documented in the package README.
- Tools return errors to the model as strings and never throw, per the toolkit conventions.
- Added the package to the coverage gate; it's at 100% (PHPStan max, type + code coverage), `composer test` green.
- Wired into the workbench agent so you can try it with `vendor/bin/testbench agent:run "..."` once `JIGSAWSTACK_API_KEY` is set.

Descriptions are authored to match the AI SDK tool set since JigsawStack's SDK doesn't expose literal description strings. Open to tweaking wording.