### PR TITLE
Widen laravel/ai constraint to ^0.7|^0.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "require-dev": {
         "laravel/pint": "^1.29.1",

--- a/src/Calculator/composer.json
+++ b/src/Calculator/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exa/composer.json
+++ b/src/Exa/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/JigsawStack/composer.json
+++ b/src/JigsawStack/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Perplexity/composer.json
+++ b/src/Perplexity/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Tavily/composer.json
+++ b/src/Tavily/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/stub/composer.json
+++ b/stub/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Widen `laravel/ai` from `^0.7` to `^0.7|^0.10` in the root, stub, and every `src/*/composer.json`.
- Verified against `laravel/ai v0.10.3`: pint, rector, phpstan, 100% type coverage, and 299 unit tests all pass.

## Why
Published toolkit packages currently cannot resolve for apps on `laravel/ai` 0.10 because Composer reads `^0.7` as `>=0.7.0 <0.8.0`. The Tool API surface these packages use (`Tool`, `Strict`, `Request`, `JsonSchema`) is unchanged in 0.10, so this is a constraint-only unblock.

## Labels
Please apply `release:patch`.

## Test plan
- [x] `composer update laravel/ai --with-all-dependencies` resolves to `v0.10.3`
- [x] `composer test` green (pint + rector + phpstan + 100% type/code coverage)


Made with [Cursor](https://cursor.com)