### PR TITLE
Add Brave Search web search tool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/var-dumper": "^8.0.8"
     },
     "replace": {
+        "shipfastlabs/toolkit-brave": "self.version",
         "shipfastlabs/toolkit-calculator": "self.version",
         "shipfastlabs/toolkit-database": "self.version",
         "shipfastlabs/toolkit-exa": "self.version",
@@ -44,6 +45,7 @@
     "autoload": {
         "psr-4": {
             "Shipfastlabs\\Toolkit\\": "src/",
+            "Shipfastlabs\\Toolkit\\Brave\\": "src/Brave/src/",
             "Shipfastlabs\\Toolkit\\Calculator\\": "src/Calculator/src/",
             "Shipfastlabs\\Toolkit\\Database\\": "src/Database/src/",
             "Shipfastlabs\\Toolkit\\Exa\\": "src/Exa/src/",
@@ -54,6 +56,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Shipfastlabs\\Toolkit\\Brave\\Tests\\": "src/Brave/tests/",
             "Shipfastlabs\\Toolkit\\Calculator\\Tests\\": "src/Calculator/tests/",
             "Shipfastlabs\\Toolkit\\Database\\Tests\\": "src/Database/tests/",
             "Shipfastlabs\\Toolkit\\Exa\\Tests\\": "src/Exa/tests/",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "require-dev": {
         "laravel/pint": "^1.29.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
     cacheDirectory=".phpunit.cache">
     <source>
         <include>
+            <directory suffix=".php">./src/Brave/src</directory>
             <directory suffix=".php">./src/Calculator/src</directory>
             <directory suffix=".php">./src/Database/src</directory>
             <directory suffix=".php">./src/JigsawStack/src</directory>

--- a/src/Brave/README.md
+++ b/src/Brave/README.md
@@ -1,0 +1,144 @@
+# shipfastlabs/toolkit-brave
+
+[![Latest Version](https://img.shields.io/packagist/v/shipfastlabs/toolkit-brave.svg)](https://packagist.org/packages/shipfastlabs/toolkit-brave)
+[![Total Downloads](https://img.shields.io/packagist/dt/shipfastlabs/toolkit-brave.svg)](https://packagist.org/packages/shipfastlabs/toolkit-brave)
+
+> Brave Search tools for the Laravel AI SDK - Web Search
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+<!-- AUTO-GENERATED: do not edit above this line. Run `tools/docgen.sh`. -->
+
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-brave
+```
+
+## Usage
+
+Register every Brave tool at once with the `Brave` helper:
+
+```php
+use Shipfastlabs\Toolkit\Brave\Brave;
+
+$tools = Brave::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\Brave\BraveSearch;
+
+$tools = [
+    new BraveSearch,
+];
+```
+
+## Tools
+
+### BraveSearch
+
+Search the web for real-time information via the Brave Search API.
+
+| Parameter         | Type    | Required | Description                                                                 |
+|-------------------|---------|----------|-----------------------------------------------------------------------------|
+| `query`           | string  | yes      | The search query to look up on the web.                                     |
+| `count`           | integer | no       | Maximum number of search results to return (1-20). Defaults to 20.          |
+| `offset`          | integer | no       | Zero-based page offset for pagination (0-9). Defaults to 0.                 |
+| `freshness`       | string  | no       | `"pd"`, `"pw"`, `"pm"`, `"py"`, or a `"YYYY-MM-DDtoYYYY-MM-DD"` range.     |
+| `safesearch`      | string  | no       | `"off"`, `"moderate"`, or `"strict"`. Defaults to `"moderate"`.             |
+| `country`         | string  | no       | Two-character country code to prefer results from.                          |
+| `search_lang`     | string  | no       | ISO 639-1 language code to prefer for result content.                       |
+| `extra_snippets`  | boolean | no       | Whether to include up to five additional excerpts per result. Defaults to false. |
+
+News, image, and local Brave endpoints are intentionally out of scope for v1.
+
+## Provider setup
+
+All tools read their API credentials from Laravel's `services` config and their optional defaults from the `ai` config.
+
+### 1. Add the Brave service to `config/services.php`
+
+```php
+// config/services.php
+
+return [
+
+    // ... existing services ...
+
+    'brave' => [
+        'key' => env('BRAVE_API_KEY'),
+    ],
+
+];
+```
+
+### 2. Add toolkit defaults to `config/ai.php`
+
+```php
+// config/ai.php
+
+return [
+
+    // ... existing laravel/ai config ...
+
+    'toolkit' => [
+        'brave' => [
+            'search' => [
+                'count' => (int) env('BRAVE_SEARCH_COUNT', 20),
+                'offset' => (int) env('BRAVE_SEARCH_OFFSET', 0),
+                'safesearch' => env('BRAVE_SEARCH_SAFESEARCH', 'moderate'),
+                'freshness' => env('BRAVE_SEARCH_FRESHNESS'),
+                'country' => env('BRAVE_SEARCH_COUNTRY'),
+                'search_lang' => env('BRAVE_SEARCH_LANG'),
+                'extra_snippets' => (bool) env('BRAVE_SEARCH_EXTRA_SNIPPETS', false),
+            ],
+        ],
+    ],
+
+];
+```
+
+### 3. Add environment variables to `.env`
+
+```dotenv
+BRAVE_API_KEY=your-key-here
+
+# Search defaults
+BRAVE_SEARCH_COUNT=20
+BRAVE_SEARCH_OFFSET=0
+BRAVE_SEARCH_SAFESEARCH=moderate
+# BRAVE_SEARCH_FRESHNESS=pw
+# BRAVE_SEARCH_COUNTRY=US
+# BRAVE_SEARCH_LANG=en
+BRAVE_SEARCH_EXTRA_SNIPPETS=false
+```
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `services.brave.key` | `BRAVE_API_KEY` | - | **Required.** Your Brave Search API key. |
+| `ai.toolkit.brave.search.count` | `BRAVE_SEARCH_COUNT` | `20` | Default search results (1-20). |
+| `ai.toolkit.brave.search.offset` | `BRAVE_SEARCH_OFFSET` | `0` | Default page offset (0-9). |
+| `ai.toolkit.brave.search.safesearch` | `BRAVE_SEARCH_SAFESEARCH` | `"moderate"` | `"off"`, `"moderate"`, or `"strict"`. |
+| `ai.toolkit.brave.search.freshness` | `BRAVE_SEARCH_FRESHNESS` | - | Optional freshness filter. |
+| `ai.toolkit.brave.search.country` | `BRAVE_SEARCH_COUNTRY` | - | Optional 2-letter country code. |
+| `ai.toolkit.brave.search.search_lang` | `BRAVE_SEARCH_LANG` | - | Optional ISO 639-1 language code. |
+| `ai.toolkit.brave.search.extra_snippets` | `BRAVE_SEARCH_EXTRA_SNIPPETS` | `false` | Include additional excerpts. |
+
+## Safety
+
+- All tools validate required inputs before calling the API.
+- Numeric parameters are clamped to their valid ranges; enums fall back to safe defaults.
+- Invalid freshness values are omitted rather than sent to the API.
+- API errors are caught and returned as friendly string messages.
+- Requires a valid Brave Search API key (`X-Subscription-Token`).
+
+## Brave Search API
+
+These tools use the [Brave Search API](https://api-dashboard.search.brave.com/). Brave offers a free tier to get started.
+
+Full API reference:
+
+- [Web Search Endpoint](https://api-dashboard.search.brave.com/api-reference/web/search/get)

--- a/src/Brave/composer.json
+++ b/src/Brave/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "shipfastlabs/toolkit-brave",
+    "description": "Brave Search tools for the Laravel AI SDK - Web Search",
+    "keywords": ["laravel", "ai", "tool", "brave", "search", "web"],
+    "license": "MIT",
+    "require": {
+        "php": "^8.4.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "laravel/ai": "^0.7|^0.10"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Brave\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Brave\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/Brave/src/Brave.php
+++ b/src/Brave/src/Brave.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Brave;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+
+class Brave
+{
+    /**
+     * @return Collection<int, Tool>
+     */
+    public static function all(): Collection
+    {
+        return new Collection([
+            new BraveSearch,
+        ]);
+    }
+}

--- a/src/Brave/src/BraveSearch.php
+++ b/src/Brave/src/BraveSearch.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Brave;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Throwable;
+
+#[Strict]
+class BraveSearch implements Tool
+{
+    public function description(): string
+    {
+        return <<<'TXT'
+            Search the web for real-time information using the Brave Search API.
+            Returns ranked web results with titles, URLs, and snippets.
+            TXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema
+                ->string()
+                ->description('The search query to look up on the web')
+                ->required(),
+            'count' => $schema
+                ->integer()
+                ->description('Maximum number of search results to return (1-20, default: 20)')
+                ->nullable()
+                ->required(),
+            'offset' => $schema
+                ->integer()
+                ->description('Zero-based page offset for pagination (0-9, default: 0)')
+                ->nullable()
+                ->required(),
+            'freshness' => $schema
+                ->string()
+                ->description("Restrict results by freshness - 'pd' (24h), 'pw' (7d), 'pm' (31d), 'py' (year), or a 'YYYY-MM-DDtoYYYY-MM-DD' range")
+                ->nullable()
+                ->required(),
+            'safesearch' => $schema
+                ->string()
+                ->description("Adult content filter - 'off', 'moderate', or 'strict' (default: 'moderate')")
+                ->nullable()
+                ->required(),
+            'country' => $schema
+                ->string()
+                ->description('Two-character country code to prefer results from (e.g., "US", "DE")')
+                ->nullable()
+                ->required(),
+            'search_lang' => $schema
+                ->string()
+                ->description('ISO 639-1 language code to prefer for result content (e.g., "en", "de")')
+                ->nullable()
+                ->required(),
+            'extra_snippets' => $schema
+                ->boolean()
+                ->description('Whether to include up to five additional excerpts per result (default: false)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $query = $request->string('query')->trim();
+
+        if ($query->isEmpty()) {
+            return 'The search query is empty. Provide a query to search for.';
+        }
+
+        $apiKey = config('services.brave.key');
+
+        if (! is_string($apiKey) || blank($apiKey)) {
+            return 'The Brave tool is not configured. Set services.brave.key in your config/services.php file.';
+        }
+
+        $count = $request->filled('count')
+            ? $request->integer('count')
+            : $this->defaultCount();
+
+        $offset = $request->filled('offset')
+            ? $request->integer('offset')
+            : $this->defaultOffset();
+
+        $queryParams = [
+            'q' => (string) $query,
+            'count' => max(1, min(20, $count)),
+            'offset' => max(0, min(9, $offset)),
+            'safesearch' => $request->filled('safesearch')
+                ? $this->validateSafesearch((string) $request->string('safesearch'))
+                : $this->defaultSafesearch(),
+        ];
+
+        $freshness = $request->filled('freshness')
+            ? $this->validateFreshness((string) $request->string('freshness'))
+            : $this->defaultFreshness();
+
+        if ($freshness !== null) {
+            $queryParams['freshness'] = $freshness;
+        }
+
+        $country = $request->filled('country')
+            ? trim((string) $request->string('country'))
+            : $this->defaultCountry();
+
+        if ($country !== null && $country !== '') {
+            $queryParams['country'] = $country;
+        }
+
+        $searchLang = $request->filled('search_lang')
+            ? trim((string) $request->string('search_lang'))
+            : $this->defaultSearchLang();
+
+        if ($searchLang !== null && $searchLang !== '') {
+            $queryParams['search_lang'] = $searchLang;
+        }
+
+        $extraSnippets = $request->filled('extra_snippets')
+            ? $request->boolean('extra_snippets')
+            : $this->defaultExtraSnippets();
+
+        if ($extraSnippets) {
+            $queryParams['extra_snippets'] = true;
+        }
+
+        try {
+            $response = Http::withHeaders([
+                'X-Subscription-Token' => $apiKey,
+                'Accept' => 'application/json',
+            ])
+                ->timeout(30)
+                ->get('https://api.search.brave.com/res/v1/web/search', $queryParams);
+        } catch (Throwable $throwable) {
+            return sprintf('The Brave search request failed: %s', $throwable->getMessage());
+        }
+
+        if ($response->failed()) {
+            return sprintf(
+                'The Brave search request failed with status %d: %s',
+                $response->status(),
+                $response->body()
+            );
+        }
+
+        $data = $response->json();
+
+        if (! is_array($data)) {
+            return 'The Brave search response was invalid.';
+        }
+
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    private function defaultCount(): int
+    {
+        $count = config('ai.toolkit.brave.search.count', 20);
+
+        return is_numeric($count) ? (int) $count : 20;
+    }
+
+    private function defaultOffset(): int
+    {
+        $offset = config('ai.toolkit.brave.search.offset', 0);
+
+        return is_numeric($offset) ? (int) $offset : 0;
+    }
+
+    private function defaultSafesearch(): string
+    {
+        $safesearch = config('ai.toolkit.brave.search.safesearch', 'moderate');
+
+        return $this->validateSafesearch(is_string($safesearch) ? $safesearch : 'moderate');
+    }
+
+    private function validateSafesearch(string $safesearch): string
+    {
+        return in_array($safesearch, ['off', 'moderate', 'strict'], true) ? $safesearch : 'moderate';
+    }
+
+    private function defaultFreshness(): ?string
+    {
+        $freshness = config('ai.toolkit.brave.search.freshness');
+
+        return is_string($freshness) ? $this->validateFreshness($freshness) : null;
+    }
+
+    private function validateFreshness(string $freshness): ?string
+    {
+        if (in_array($freshness, ['pd', 'pw', 'pm', 'py'], true)) {
+            return $freshness;
+        }
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}to\d{4}-\d{2}-\d{2}$/', $freshness) === 1) {
+            return $freshness;
+        }
+
+        return null;
+    }
+
+    private function defaultCountry(): ?string
+    {
+        $country = config('ai.toolkit.brave.search.country');
+
+        return is_string($country) && $country !== '' ? $country : null;
+    }
+
+    private function defaultSearchLang(): ?string
+    {
+        $searchLang = config('ai.toolkit.brave.search.search_lang');
+
+        return is_string($searchLang) && $searchLang !== '' ? $searchLang : null;
+    }
+
+    private function defaultExtraSnippets(): bool
+    {
+        return (bool) config('ai.toolkit.brave.search.extra_snippets', false);
+    }
+}

--- a/src/Brave/tests/BraveSearchTest.php
+++ b/src/Brave/tests/BraveSearchTest.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Brave\BraveSearch;
+
+it('has a description', function (): void {
+    expect((new BraveSearch)->description())->toContain('Brave Search');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new BraveSearch))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new BraveSearch)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('query')
+        ->and($schema)->toHaveKey('count')
+        ->and($schema)->toHaveKey('offset')
+        ->and($schema)->toHaveKey('freshness')
+        ->and($schema)->toHaveKey('safesearch')
+        ->and($schema)->toHaveKey('country')
+        ->and($schema)->toHaveKey('search_lang')
+        ->and($schema)->toHaveKey('extra_snippets');
+});
+
+it('returns an error when the query is empty', function (): void {
+    $result = (new BraveSearch)->handle(new Request(['query' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.brave.key');
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('returns search results on success', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response([
+            'query' => ['original' => 'Laravel news'],
+            'web' => [
+                'results' => [
+                    [
+                        'title' => 'Laravel 11 Released',
+                        'url' => 'https://laravel.com',
+                        'description' => 'Laravel 11 is here with new features.',
+                    ],
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('Laravel 11 Released')
+        ->and($result)->toContain('Laravel 11 is here');
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('X-Subscription-Token', 'test-key')
+        && $request->hasHeader('Accept', 'application/json')
+        && $request->url() === 'https://api.search.brave.com/res/v1/web/search?q=Laravel%20news&count=20&offset=0&safesearch=moderate');
+});
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response('Invalid API key', 401),
+    ]);
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('failed with status 401');
+});
+
+it('returns an error when the response is not an array', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response('"ok"', 200, [
+            'Content-Type' => 'application/json',
+        ]),
+    ]);
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('response was invalid');
+});
+
+it('respects custom count and offset', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request([
+        'query' => 'test',
+        'count' => 5,
+        'offset' => 2,
+    ]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=5')
+        && str_contains($request->url(), 'offset=2'));
+});
+
+it('respects custom safesearch freshness country and language', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request([
+        'query' => 'test',
+        'safesearch' => 'strict',
+        'freshness' => 'pw',
+        'country' => 'DE',
+        'search_lang' => 'de',
+        'extra_snippets' => true,
+    ]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'safesearch=strict')
+        && str_contains($request->url(), 'freshness=pw')
+        && str_contains($request->url(), 'country=DE')
+        && str_contains($request->url(), 'search_lang=de')
+        && str_contains($request->url(), 'extra_snippets=1'));
+});
+
+it('accepts a custom freshness date range', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request([
+        'query' => 'test',
+        'freshness' => '2022-04-01to2022-07-30',
+    ]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'freshness=2022-04-01to2022-07-30'));
+});
+
+it('uses defaults when optional params are omitted', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test']));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=20')
+        && str_contains($request->url(), 'offset=0')
+        && str_contains($request->url(), 'safesearch=moderate')
+        && ! str_contains($request->url(), 'freshness=')
+        && ! str_contains($request->url(), 'country=')
+        && ! str_contains($request->url(), 'search_lang=')
+        && ! str_contains($request->url(), 'extra_snippets='));
+});
+
+it('uses defaults when optional params are explicitly null', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request([
+        'query' => 'test',
+        'count' => null,
+        'offset' => null,
+        'freshness' => null,
+        'safesearch' => null,
+        'country' => null,
+        'search_lang' => null,
+        'extra_snippets' => null,
+    ]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=20')
+        && str_contains($request->url(), 'offset=0')
+        && str_contains($request->url(), 'safesearch=moderate'));
+});
+
+it('uses configured defaults when optional params are omitted', function (): void {
+    config()->set('services.brave.key', 'test-key');
+    config()->set('ai.toolkit.brave.search.count', 8);
+    config()->set('ai.toolkit.brave.search.offset', 1);
+    config()->set('ai.toolkit.brave.search.safesearch', 'off');
+    config()->set('ai.toolkit.brave.search.freshness', 'pm');
+    config()->set('ai.toolkit.brave.search.country', 'US');
+    config()->set('ai.toolkit.brave.search.search_lang', 'en');
+    config()->set('ai.toolkit.brave.search.extra_snippets', true);
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test']));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=8')
+        && str_contains($request->url(), 'offset=1')
+        && str_contains($request->url(), 'safesearch=off')
+        && str_contains($request->url(), 'freshness=pm')
+        && str_contains($request->url(), 'country=US')
+        && str_contains($request->url(), 'search_lang=en')
+        && str_contains($request->url(), 'extra_snippets=1'));
+});
+
+it('falls back to moderate for invalid safesearch values', function (string $input): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test', 'safesearch' => $input]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'safesearch=moderate'));
+})->with([
+    'empty' => [''],
+    'random' => ['foobar'],
+    'wrong case' => ['Strict'],
+]);
+
+it('omits invalid freshness values', function (string $input): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test', 'freshness' => $input]));
+
+    Http::assertSent(fn ($request): bool => ! str_contains($request->url(), 'freshness='));
+})->with([
+    'empty' => [''],
+    'random' => ['last-week'],
+    'wrong case' => ['PW'],
+]);
+
+it('falls back when configured defaults are invalid', function (): void {
+    config()->set('services.brave.key', 'test-key');
+    config()->set('ai.toolkit.brave.search.count', 'not-a-number');
+    config()->set('ai.toolkit.brave.search.offset', 'nope');
+    config()->set('ai.toolkit.brave.search.safesearch', 'Strict');
+    config()->set('ai.toolkit.brave.search.freshness', 'last-week');
+    config()->set('ai.toolkit.brave.search.country', '');
+    config()->set('ai.toolkit.brave.search.search_lang', '');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test']));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=20')
+        && str_contains($request->url(), 'offset=0')
+        && str_contains($request->url(), 'safesearch=moderate')
+        && ! str_contains($request->url(), 'freshness=')
+        && ! str_contains($request->url(), 'country=')
+        && ! str_contains($request->url(), 'search_lang='));
+});
+
+it('clamps count between 1 and 20', function (int $input, int $expected): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test', 'count' => $input]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count='.$expected));
+})->with([
+    'too low' => [-5, 1],
+    'zero' => [0, 1],
+    'minimum' => [1, 1],
+    'maximum' => [20, 20],
+    'too high' => [50, 20],
+]);
+
+it('clamps offset between 0 and 9', function (int $input, int $expected): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test', 'offset' => $input]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'offset='.$expected));
+})->with([
+    'too low' => [-3, 0],
+    'minimum' => [0, 0],
+    'maximum' => [9, 9],
+    'too high' => [12, 9],
+]);
+
+it('returns a friendly error when the request throws', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake(function (): void {
+        throw new RuntimeException('Connection timed out');
+    });
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'test']));
+
+    expect($result)->toContain('request failed')
+        ->and($result)->toContain('Connection timed out');
+});

--- a/src/Brave/tests/BraveTest.php
+++ b/src/Brave/tests/BraveTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Shipfastlabs\Toolkit\Brave\Brave;
+use Shipfastlabs\Toolkit\Brave\BraveSearch;
+
+it('creates a collection of all Brave tools', function (): void {
+    $tools = Brave::all();
+
+    expect($tools)->toBeInstanceOf(Collection::class)
+        ->and($tools)->toHaveCount(1)
+        ->and($tools->all())->toContainOnlyInstancesOf(Tool::class);
+});
+
+it('includes each Brave tool exactly once', function (): void {
+    $classes = Brave::all()->map(fn ($tool): string => $tool::class);
+
+    expect($classes->all())->toEqualCanonicalizing([
+        BraveSearch::class,
+    ]);
+});

--- a/src/Calculator/composer.json
+++ b/src/Calculator/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exa/composer.json
+++ b/src/Exa/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/JigsawStack/composer.json
+++ b/src/JigsawStack/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Perplexity/composer.json
+++ b/src/Perplexity/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Tavily/composer.json
+++ b/src/Tavily/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/stub/composer.json
+++ b/stub/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- New `src/Brave` package (`shipfastlabs/toolkit-brave`) with `BraveSearch` and `Brave::all()`.
- Calls Brave Web Search via `GET https://api.search.brave.com/res/v1/web/search` with `X-Subscription-Token`.
- Reads credentials from `services.brave.key` and defaults from `ai.toolkit.brave.search.*`.
- v1 covers web search only; news/image/local are deferred for coverage simplicity.

## Depends on
Please also merge #15 (`laravel/ai` constraint widen to `^0.7|^0.10`) so consumers on modern `laravel/ai` can install this.

## Labels
Please apply `new-tool`.

## Test plan
- [x] `composer test` green (pint + rector + phpstan + 100% type/code coverage)
- [x] 332 tests passing including BraveSearch branch coverage (empty query, missing key, success, failure, invalid JSON, clamps, freshness/safesearch validation, configured defaults, throw)


Made with [Cursor](https://cursor.com)