### PR TITLE
Extract Citations and Scout toolkit packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/var-dumper": "^8.0.8"
     },
     "replace": {
+        "shipfastlabs/toolkit-brave": "self.version",
         "shipfastlabs/toolkit-calculator": "self.version",
         "shipfastlabs/toolkit-database": "self.version",
         "shipfastlabs/toolkit-exa": "self.version",
@@ -44,6 +45,7 @@
     "autoload": {
         "psr-4": {
             "Shipfastlabs\\Toolkit\\": "src/",
+            "Shipfastlabs\\Toolkit\\Brave\\": "src/Brave/src/",
             "Shipfastlabs\\Toolkit\\Calculator\\": "src/Calculator/src/",
             "Shipfastlabs\\Toolkit\\Database\\": "src/Database/src/",
             "Shipfastlabs\\Toolkit\\Exa\\": "src/Exa/src/",
@@ -54,6 +56,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Shipfastlabs\\Toolkit\\Brave\\Tests\\": "src/Brave/tests/",
             "Shipfastlabs\\Toolkit\\Calculator\\Tests\\": "src/Calculator/tests/",
             "Shipfastlabs\\Toolkit\\Database\\Tests\\": "src/Database/tests/",
             "Shipfastlabs\\Toolkit\\Exa\\Tests\\": "src/Exa/tests/",

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,12 @@
     "replace": {
         "shipfastlabs/toolkit-brave": "self.version",
         "shipfastlabs/toolkit-calculator": "self.version",
+        "shipfastlabs/toolkit-citations": "self.version",
         "shipfastlabs/toolkit-database": "self.version",
         "shipfastlabs/toolkit-exa": "self.version",
         "shipfastlabs/toolkit-jigsawstack": "self.version",
         "shipfastlabs/toolkit-perplexity": "self.version",
+        "shipfastlabs/toolkit-scout": "self.version",
         "shipfastlabs/toolkit-stub": "self.version",
         "shipfastlabs/toolkit-tavily": "self.version"
     },
@@ -47,10 +49,12 @@
             "Shipfastlabs\\Toolkit\\": "src/",
             "Shipfastlabs\\Toolkit\\Brave\\": "src/Brave/src/",
             "Shipfastlabs\\Toolkit\\Calculator\\": "src/Calculator/src/",
+            "Shipfastlabs\\Toolkit\\Citations\\": "src/Citations/src/",
             "Shipfastlabs\\Toolkit\\Database\\": "src/Database/src/",
             "Shipfastlabs\\Toolkit\\Exa\\": "src/Exa/src/",
             "Shipfastlabs\\Toolkit\\JigsawStack\\": "src/JigsawStack/src/",
             "Shipfastlabs\\Toolkit\\Perplexity\\": "src/Perplexity/src/",
+            "Shipfastlabs\\Toolkit\\Scout\\": "src/Scout/src/",
             "Shipfastlabs\\Toolkit\\Tavily\\": "src/Tavily/src/"
         }
     },
@@ -58,10 +62,12 @@
         "psr-4": {
             "Shipfastlabs\\Toolkit\\Brave\\Tests\\": "src/Brave/tests/",
             "Shipfastlabs\\Toolkit\\Calculator\\Tests\\": "src/Calculator/tests/",
+            "Shipfastlabs\\Toolkit\\Citations\\Tests\\": "src/Citations/tests/",
             "Shipfastlabs\\Toolkit\\Database\\Tests\\": "src/Database/tests/",
             "Shipfastlabs\\Toolkit\\Exa\\Tests\\": "src/Exa/tests/",
             "Shipfastlabs\\Toolkit\\JigsawStack\\Tests\\": "src/JigsawStack/tests/",
             "Shipfastlabs\\Toolkit\\Perplexity\\Tests\\": "src/Perplexity/tests/",
+            "Shipfastlabs\\Toolkit\\Scout\\Tests\\": "src/Scout/tests/",
             "Shipfastlabs\\Toolkit\\Tavily\\Tests\\": "src/Tavily/tests/",
             "Shipfastlabs\\Toolkit\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "require-dev": {
         "laravel/pint": "^1.29.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,10 @@
         <include>
             <directory suffix=".php">./src/Brave/src</directory>
             <directory suffix=".php">./src/Calculator/src</directory>
+            <directory suffix=".php">./src/Citations/src</directory>
             <directory suffix=".php">./src/Database/src</directory>
             <directory suffix=".php">./src/JigsawStack/src</directory>
+            <directory suffix=".php">./src/Scout/src</directory>
         </include>
     </source>
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
     cacheDirectory=".phpunit.cache">
     <source>
         <include>
+            <directory suffix=".php">./src/Brave/src</directory>
             <directory suffix=".php">./src/Calculator/src</directory>
             <directory suffix=".php">./src/Database/src</directory>
             <directory suffix=".php">./src/JigsawStack/src</directory>

--- a/src/Brave/README.md
+++ b/src/Brave/README.md
@@ -1,0 +1,144 @@
+# shipfastlabs/toolkit-brave
+
+[![Latest Version](https://img.shields.io/packagist/v/shipfastlabs/toolkit-brave.svg)](https://packagist.org/packages/shipfastlabs/toolkit-brave)
+[![Total Downloads](https://img.shields.io/packagist/dt/shipfastlabs/toolkit-brave.svg)](https://packagist.org/packages/shipfastlabs/toolkit-brave)
+
+> Brave Search tools for the Laravel AI SDK - Web Search
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+<!-- AUTO-GENERATED: do not edit above this line. Run `tools/docgen.sh`. -->
+
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-brave
+```
+
+## Usage
+
+Register every Brave tool at once with the `Brave` helper:
+
+```php
+use Shipfastlabs\Toolkit\Brave\Brave;
+
+$tools = Brave::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\Brave\BraveSearch;
+
+$tools = [
+    new BraveSearch,
+];
+```
+
+## Tools
+
+### BraveSearch
+
+Search the web for real-time information via the Brave Search API.
+
+| Parameter         | Type    | Required | Description                                                                 |
+|-------------------|---------|----------|-----------------------------------------------------------------------------|
+| `query`           | string  | yes      | The search query to look up on the web.                                     |
+| `count`           | integer | no       | Maximum number of search results to return (1-20). Defaults to 20.          |
+| `offset`          | integer | no       | Zero-based page offset for pagination (0-9). Defaults to 0.                 |
+| `freshness`       | string  | no       | `"pd"`, `"pw"`, `"pm"`, `"py"`, or a `"YYYY-MM-DDtoYYYY-MM-DD"` range.     |
+| `safesearch`      | string  | no       | `"off"`, `"moderate"`, or `"strict"`. Defaults to `"moderate"`.             |
+| `country`         | string  | no       | Two-character country code to prefer results from.                          |
+| `search_lang`     | string  | no       | ISO 639-1 language code to prefer for result content.                       |
+| `extra_snippets`  | boolean | no       | Whether to include up to five additional excerpts per result. Defaults to false. |
+
+News, image, and local Brave endpoints are intentionally out of scope for v1.
+
+## Provider setup
+
+All tools read their API credentials from Laravel's `services` config and their optional defaults from the `ai` config.
+
+### 1. Add the Brave service to `config/services.php`
+
+```php
+// config/services.php
+
+return [
+
+    // ... existing services ...
+
+    'brave' => [
+        'key' => env('BRAVE_API_KEY'),
+    ],
+
+];
+```
+
+### 2. Add toolkit defaults to `config/ai.php`
+
+```php
+// config/ai.php
+
+return [
+
+    // ... existing laravel/ai config ...
+
+    'toolkit' => [
+        'brave' => [
+            'search' => [
+                'count' => (int) env('BRAVE_SEARCH_COUNT', 20),
+                'offset' => (int) env('BRAVE_SEARCH_OFFSET', 0),
+                'safesearch' => env('BRAVE_SEARCH_SAFESEARCH', 'moderate'),
+                'freshness' => env('BRAVE_SEARCH_FRESHNESS'),
+                'country' => env('BRAVE_SEARCH_COUNTRY'),
+                'search_lang' => env('BRAVE_SEARCH_LANG'),
+                'extra_snippets' => (bool) env('BRAVE_SEARCH_EXTRA_SNIPPETS', false),
+            ],
+        ],
+    ],
+
+];
+```
+
+### 3. Add environment variables to `.env`
+
+```dotenv
+BRAVE_API_KEY=your-key-here
+
+# Search defaults
+BRAVE_SEARCH_COUNT=20
+BRAVE_SEARCH_OFFSET=0
+BRAVE_SEARCH_SAFESEARCH=moderate
+# BRAVE_SEARCH_FRESHNESS=pw
+# BRAVE_SEARCH_COUNTRY=US
+# BRAVE_SEARCH_LANG=en
+BRAVE_SEARCH_EXTRA_SNIPPETS=false
+```
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `services.brave.key` | `BRAVE_API_KEY` | - | **Required.** Your Brave Search API key. |
+| `ai.toolkit.brave.search.count` | `BRAVE_SEARCH_COUNT` | `20` | Default search results (1-20). |
+| `ai.toolkit.brave.search.offset` | `BRAVE_SEARCH_OFFSET` | `0` | Default page offset (0-9). |
+| `ai.toolkit.brave.search.safesearch` | `BRAVE_SEARCH_SAFESEARCH` | `"moderate"` | `"off"`, `"moderate"`, or `"strict"`. |
+| `ai.toolkit.brave.search.freshness` | `BRAVE_SEARCH_FRESHNESS` | - | Optional freshness filter. |
+| `ai.toolkit.brave.search.country` | `BRAVE_SEARCH_COUNTRY` | - | Optional 2-letter country code. |
+| `ai.toolkit.brave.search.search_lang` | `BRAVE_SEARCH_LANG` | - | Optional ISO 639-1 language code. |
+| `ai.toolkit.brave.search.extra_snippets` | `BRAVE_SEARCH_EXTRA_SNIPPETS` | `false` | Include additional excerpts. |
+
+## Safety
+
+- All tools validate required inputs before calling the API.
+- Numeric parameters are clamped to their valid ranges; enums fall back to safe defaults.
+- Invalid freshness values are omitted rather than sent to the API.
+- API errors are caught and returned as friendly string messages.
+- Requires a valid Brave Search API key (`X-Subscription-Token`).
+
+## Brave Search API
+
+These tools use the [Brave Search API](https://api-dashboard.search.brave.com/). Brave offers a free tier to get started.
+
+Full API reference:
+
+- [Web Search Endpoint](https://api-dashboard.search.brave.com/api-reference/web/search/get)

--- a/src/Brave/composer.json
+++ b/src/Brave/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "shipfastlabs/toolkit-brave",
+    "description": "Brave Search tools for the Laravel AI SDK - Web Search",
+    "keywords": ["laravel", "ai", "tool", "brave", "search", "web"],
+    "license": "MIT",
+    "require": {
+        "php": "^8.4.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "laravel/ai": "^0.7|^0.10"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Brave\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Brave\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/Brave/src/Brave.php
+++ b/src/Brave/src/Brave.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Brave;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+
+class Brave
+{
+    /**
+     * @return Collection<int, Tool>
+     */
+    public static function all(): Collection
+    {
+        return new Collection([
+            new BraveSearch,
+        ]);
+    }
+}

--- a/src/Brave/src/BraveSearch.php
+++ b/src/Brave/src/BraveSearch.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Brave;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Throwable;
+
+#[Strict]
+class BraveSearch implements Tool
+{
+    public function description(): string
+    {
+        return <<<'TXT'
+            Search the web for real-time information using the Brave Search API.
+            Returns ranked web results with titles, URLs, and snippets.
+            TXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema
+                ->string()
+                ->description('The search query to look up on the web')
+                ->required(),
+            'count' => $schema
+                ->integer()
+                ->description('Maximum number of search results to return (1-20, default: 20)')
+                ->nullable()
+                ->required(),
+            'offset' => $schema
+                ->integer()
+                ->description('Zero-based page offset for pagination (0-9, default: 0)')
+                ->nullable()
+                ->required(),
+            'freshness' => $schema
+                ->string()
+                ->description("Restrict results by freshness - 'pd' (24h), 'pw' (7d), 'pm' (31d), 'py' (year), or a 'YYYY-MM-DDtoYYYY-MM-DD' range")
+                ->nullable()
+                ->required(),
+            'safesearch' => $schema
+                ->string()
+                ->description("Adult content filter - 'off', 'moderate', or 'strict' (default: 'moderate')")
+                ->nullable()
+                ->required(),
+            'country' => $schema
+                ->string()
+                ->description('Two-character country code to prefer results from (e.g., "US", "DE")')
+                ->nullable()
+                ->required(),
+            'search_lang' => $schema
+                ->string()
+                ->description('ISO 639-1 language code to prefer for result content (e.g., "en", "de")')
+                ->nullable()
+                ->required(),
+            'extra_snippets' => $schema
+                ->boolean()
+                ->description('Whether to include up to five additional excerpts per result (default: false)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $query = $request->string('query')->trim();
+
+        if ($query->isEmpty()) {
+            return 'The search query is empty. Provide a query to search for.';
+        }
+
+        $apiKey = config('services.brave.key');
+
+        if (! is_string($apiKey) || blank($apiKey)) {
+            return 'The Brave tool is not configured. Set services.brave.key in your config/services.php file.';
+        }
+
+        $count = $request->filled('count')
+            ? $request->integer('count')
+            : $this->defaultCount();
+
+        $offset = $request->filled('offset')
+            ? $request->integer('offset')
+            : $this->defaultOffset();
+
+        $queryParams = [
+            'q' => (string) $query,
+            'count' => max(1, min(20, $count)),
+            'offset' => max(0, min(9, $offset)),
+            'safesearch' => $request->filled('safesearch')
+                ? $this->validateSafesearch((string) $request->string('safesearch'))
+                : $this->defaultSafesearch(),
+        ];
+
+        $freshness = $request->filled('freshness')
+            ? $this->validateFreshness((string) $request->string('freshness'))
+            : $this->defaultFreshness();
+
+        if ($freshness !== null) {
+            $queryParams['freshness'] = $freshness;
+        }
+
+        $country = $request->filled('country')
+            ? trim((string) $request->string('country'))
+            : $this->defaultCountry();
+
+        if ($country !== null && $country !== '') {
+            $queryParams['country'] = $country;
+        }
+
+        $searchLang = $request->filled('search_lang')
+            ? trim((string) $request->string('search_lang'))
+            : $this->defaultSearchLang();
+
+        if ($searchLang !== null && $searchLang !== '') {
+            $queryParams['search_lang'] = $searchLang;
+        }
+
+        $extraSnippets = $request->filled('extra_snippets')
+            ? $request->boolean('extra_snippets')
+            : $this->defaultExtraSnippets();
+
+        if ($extraSnippets) {
+            $queryParams['extra_snippets'] = true;
+        }
+
+        try {
+            $response = Http::withHeaders([
+                'X-Subscription-Token' => $apiKey,
+                'Accept' => 'application/json',
+            ])
+                ->timeout(30)
+                ->get('https://api.search.brave.com/res/v1/web/search', $queryParams);
+        } catch (Throwable $throwable) {
+            return sprintf('The Brave search request failed: %s', $throwable->getMessage());
+        }
+
+        if ($response->failed()) {
+            return sprintf(
+                'The Brave search request failed with status %d: %s',
+                $response->status(),
+                $response->body()
+            );
+        }
+
+        $data = $response->json();
+
+        if (! is_array($data)) {
+            return 'The Brave search response was invalid.';
+        }
+
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    private function defaultCount(): int
+    {
+        $count = config('ai.toolkit.brave.search.count', 20);
+
+        return is_numeric($count) ? (int) $count : 20;
+    }
+
+    private function defaultOffset(): int
+    {
+        $offset = config('ai.toolkit.brave.search.offset', 0);
+
+        return is_numeric($offset) ? (int) $offset : 0;
+    }
+
+    private function defaultSafesearch(): string
+    {
+        $safesearch = config('ai.toolkit.brave.search.safesearch', 'moderate');
+
+        return $this->validateSafesearch(is_string($safesearch) ? $safesearch : 'moderate');
+    }
+
+    private function validateSafesearch(string $safesearch): string
+    {
+        return in_array($safesearch, ['off', 'moderate', 'strict'], true) ? $safesearch : 'moderate';
+    }
+
+    private function defaultFreshness(): ?string
+    {
+        $freshness = config('ai.toolkit.brave.search.freshness');
+
+        return is_string($freshness) ? $this->validateFreshness($freshness) : null;
+    }
+
+    private function validateFreshness(string $freshness): ?string
+    {
+        if (in_array($freshness, ['pd', 'pw', 'pm', 'py'], true)) {
+            return $freshness;
+        }
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}to\d{4}-\d{2}-\d{2}$/', $freshness) === 1) {
+            return $freshness;
+        }
+
+        return null;
+    }
+
+    private function defaultCountry(): ?string
+    {
+        $country = config('ai.toolkit.brave.search.country');
+
+        return is_string($country) && $country !== '' ? $country : null;
+    }
+
+    private function defaultSearchLang(): ?string
+    {
+        $searchLang = config('ai.toolkit.brave.search.search_lang');
+
+        return is_string($searchLang) && $searchLang !== '' ? $searchLang : null;
+    }
+
+    private function defaultExtraSnippets(): bool
+    {
+        return (bool) config('ai.toolkit.brave.search.extra_snippets', false);
+    }
+}

--- a/src/Brave/tests/BraveSearchTest.php
+++ b/src/Brave/tests/BraveSearchTest.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Brave\BraveSearch;
+
+it('has a description', function (): void {
+    expect((new BraveSearch)->description())->toContain('Brave Search');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new BraveSearch))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new BraveSearch)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('query')
+        ->and($schema)->toHaveKey('count')
+        ->and($schema)->toHaveKey('offset')
+        ->and($schema)->toHaveKey('freshness')
+        ->and($schema)->toHaveKey('safesearch')
+        ->and($schema)->toHaveKey('country')
+        ->and($schema)->toHaveKey('search_lang')
+        ->and($schema)->toHaveKey('extra_snippets');
+});
+
+it('returns an error when the query is empty', function (): void {
+    $result = (new BraveSearch)->handle(new Request(['query' => '   ']));
+
+    expect($result)->toContain('empty');
+});
+
+it('returns an error when no api key is configured', function (): void {
+    config()->set('services.brave.key');
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('not configured');
+});
+
+it('returns search results on success', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response([
+            'query' => ['original' => 'Laravel news'],
+            'web' => [
+                'results' => [
+                    [
+                        'title' => 'Laravel 11 Released',
+                        'url' => 'https://laravel.com',
+                        'description' => 'Laravel 11 is here with new features.',
+                    ],
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('Laravel 11 Released')
+        ->and($result)->toContain('Laravel 11 is here');
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('X-Subscription-Token', 'test-key')
+        && $request->hasHeader('Accept', 'application/json')
+        && $request->url() === 'https://api.search.brave.com/res/v1/web/search?q=Laravel%20news&count=20&offset=0&safesearch=moderate');
+});
+
+it('returns an error when the api responds with a failure', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response('Invalid API key', 401),
+    ]);
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('failed with status 401');
+});
+
+it('returns an error when the response is not an array', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response('"ok"', 200, [
+            'Content-Type' => 'application/json',
+        ]),
+    ]);
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'Laravel news']));
+
+    expect($result)->toContain('response was invalid');
+});
+
+it('respects custom count and offset', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request([
+        'query' => 'test',
+        'count' => 5,
+        'offset' => 2,
+    ]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=5')
+        && str_contains($request->url(), 'offset=2'));
+});
+
+it('respects custom safesearch freshness country and language', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request([
+        'query' => 'test',
+        'safesearch' => 'strict',
+        'freshness' => 'pw',
+        'country' => 'DE',
+        'search_lang' => 'de',
+        'extra_snippets' => true,
+    ]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'safesearch=strict')
+        && str_contains($request->url(), 'freshness=pw')
+        && str_contains($request->url(), 'country=DE')
+        && str_contains($request->url(), 'search_lang=de')
+        && str_contains($request->url(), 'extra_snippets=1'));
+});
+
+it('accepts a custom freshness date range', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request([
+        'query' => 'test',
+        'freshness' => '2022-04-01to2022-07-30',
+    ]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'freshness=2022-04-01to2022-07-30'));
+});
+
+it('uses defaults when optional params are omitted', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test']));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=20')
+        && str_contains($request->url(), 'offset=0')
+        && str_contains($request->url(), 'safesearch=moderate')
+        && ! str_contains($request->url(), 'freshness=')
+        && ! str_contains($request->url(), 'country=')
+        && ! str_contains($request->url(), 'search_lang=')
+        && ! str_contains($request->url(), 'extra_snippets='));
+});
+
+it('uses defaults when optional params are explicitly null', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request([
+        'query' => 'test',
+        'count' => null,
+        'offset' => null,
+        'freshness' => null,
+        'safesearch' => null,
+        'country' => null,
+        'search_lang' => null,
+        'extra_snippets' => null,
+    ]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=20')
+        && str_contains($request->url(), 'offset=0')
+        && str_contains($request->url(), 'safesearch=moderate'));
+});
+
+it('uses configured defaults when optional params are omitted', function (): void {
+    config()->set('services.brave.key', 'test-key');
+    config()->set('ai.toolkit.brave.search.count', 8);
+    config()->set('ai.toolkit.brave.search.offset', 1);
+    config()->set('ai.toolkit.brave.search.safesearch', 'off');
+    config()->set('ai.toolkit.brave.search.freshness', 'pm');
+    config()->set('ai.toolkit.brave.search.country', 'US');
+    config()->set('ai.toolkit.brave.search.search_lang', 'en');
+    config()->set('ai.toolkit.brave.search.extra_snippets', true);
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test']));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=8')
+        && str_contains($request->url(), 'offset=1')
+        && str_contains($request->url(), 'safesearch=off')
+        && str_contains($request->url(), 'freshness=pm')
+        && str_contains($request->url(), 'country=US')
+        && str_contains($request->url(), 'search_lang=en')
+        && str_contains($request->url(), 'extra_snippets=1'));
+});
+
+it('falls back to moderate for invalid safesearch values', function (string $input): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test', 'safesearch' => $input]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'safesearch=moderate'));
+})->with([
+    'empty' => [''],
+    'random' => ['foobar'],
+    'wrong case' => ['Strict'],
+]);
+
+it('omits invalid freshness values', function (string $input): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test', 'freshness' => $input]));
+
+    Http::assertSent(fn ($request): bool => ! str_contains($request->url(), 'freshness='));
+})->with([
+    'empty' => [''],
+    'random' => ['last-week'],
+    'wrong case' => ['PW'],
+]);
+
+it('falls back when configured defaults are invalid', function (): void {
+    config()->set('services.brave.key', 'test-key');
+    config()->set('ai.toolkit.brave.search.count', 'not-a-number');
+    config()->set('ai.toolkit.brave.search.offset', 'nope');
+    config()->set('ai.toolkit.brave.search.safesearch', 'Strict');
+    config()->set('ai.toolkit.brave.search.freshness', 'last-week');
+    config()->set('ai.toolkit.brave.search.country', '');
+    config()->set('ai.toolkit.brave.search.search_lang', '');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test']));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count=20')
+        && str_contains($request->url(), 'offset=0')
+        && str_contains($request->url(), 'safesearch=moderate')
+        && ! str_contains($request->url(), 'freshness=')
+        && ! str_contains($request->url(), 'country=')
+        && ! str_contains($request->url(), 'search_lang='));
+});
+
+it('clamps count between 1 and 20', function (int $input, int $expected): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test', 'count' => $input]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'count='.$expected));
+})->with([
+    'too low' => [-5, 1],
+    'zero' => [0, 1],
+    'minimum' => [1, 1],
+    'maximum' => [20, 20],
+    'too high' => [50, 20],
+]);
+
+it('clamps offset between 0 and 9', function (int $input, int $expected): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake([
+        'api.search.brave.com/*' => Http::response(['web' => ['results' => []]]),
+    ]);
+
+    (new BraveSearch)->handle(new Request(['query' => 'test', 'offset' => $input]));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'offset='.$expected));
+})->with([
+    'too low' => [-3, 0],
+    'minimum' => [0, 0],
+    'maximum' => [9, 9],
+    'too high' => [12, 9],
+]);
+
+it('returns a friendly error when the request throws', function (): void {
+    config()->set('services.brave.key', 'test-key');
+
+    Http::fake(function (): void {
+        throw new RuntimeException('Connection timed out');
+    });
+
+    $result = (new BraveSearch)->handle(new Request(['query' => 'test']));
+
+    expect($result)->toContain('request failed')
+        ->and($result)->toContain('Connection timed out');
+});

--- a/src/Brave/tests/BraveTest.php
+++ b/src/Brave/tests/BraveTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Shipfastlabs\Toolkit\Brave\Brave;
+use Shipfastlabs\Toolkit\Brave\BraveSearch;
+
+it('creates a collection of all Brave tools', function (): void {
+    $tools = Brave::all();
+
+    expect($tools)->toBeInstanceOf(Collection::class)
+        ->and($tools)->toHaveCount(1)
+        ->and($tools->all())->toContainOnlyInstancesOf(Tool::class);
+});
+
+it('includes each Brave tool exactly once', function (): void {
+    $classes = Brave::all()->map(fn ($tool): string => $tool::class);
+
+    expect($classes->all())->toEqualCanonicalizing([
+        BraveSearch::class,
+    ]);
+});

--- a/src/Calculator/composer.json
+++ b/src/Calculator/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Citations/README.md
+++ b/src/Citations/README.md
@@ -1,0 +1,78 @@
+# shipfastlabs/toolkit-citations
+
+[![Latest Version](https://img.shields.io/packagist/v/shipfastlabs/toolkit-citations.svg)](https://packagist.org/packages/shipfastlabs/toolkit-citations)
+[![Total Downloads](https://img.shields.io/packagist/dt/shipfastlabs/toolkit-citations.svg)](https://packagist.org/packages/shipfastlabs/toolkit-citations)
+
+> Citation validation tools for the Laravel AI SDK
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+<!-- AUTO-GENERATED: do not edit above this line. Run `tools/docgen.sh`. -->
+
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-citations
+```
+
+## Usage
+
+Register every Citations tool at once with the `Citations` helper:
+
+```php
+use Shipfastlabs\Toolkit\Citations\Citations;
+
+$tools = Citations::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\Citations\CitationValidator;
+
+$tools = [
+    new CitationValidator,
+];
+```
+
+## Tools
+
+### CitationValidator
+
+Validate citation tokens in Markdown against a declared citation list and an allow-list of available sources.
+
+| Parameter       | Type   | Required | Description                                                                 |
+|-----------------|--------|----------|-----------------------------------------------------------------------------|
+| `body_markdown` | string | yes      | Markdown body that may contain citation tokens like `[type:id]`.            |
+| `citations`     | array  | yes      | Declared citations. Each item should include `type`, `id`, and optional `role`. |
+| `sources`       | array  | yes      | Available sources. Each item should include `entity_type`/`type` and `entity_id`/`id`. |
+
+Returns JSON with `valid`, `coverage`, referenced/declared/unknown/undeclared/duplicate tokens, and `warnings`.
+
+## Configuration
+
+Tools do not ship config files. Add optional defaults to `config/ai.php`:
+
+```php
+'toolkit' => [
+    'citations' => [
+        'entity_types' => ['tag', 'category', 'performer'],
+        'roles' => ['primary', 'supporting', 'mention'],
+        // Optional full regex override. Defaults to /[(types):(id)]/.
+        // 'token_pattern' => '/\[(tag|category|performer):([1-9][0-9]*)\]/',
+    ],
+],
+```
+
+| Config key | Default | Description |
+|---|---|---|
+| `ai.toolkit.citations.entity_types` | `tag`, `category`, `performer` | Allowed citation entity types. |
+| `ai.toolkit.citations.roles` | `primary`, `supporting`, `mention` | Allowed citation roles. Empty disables role validation. |
+| `ai.toolkit.citations.token_pattern` | derived from entity types | Optional full regex override for body token extraction. |
+
+## Safety
+
+- Invalid citation shapes are reported as warnings instead of throwing.
+- Unknown, undeclared, and duplicate tokens are returned for the model to correct.
+- Entity types and roles are constrained by configuration allow-lists.

--- a/src/Citations/composer.json
+++ b/src/Citations/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "shipfastlabs/toolkit-citations",
+    "description": "Citation validation tools for the Laravel AI SDK",
+    "keywords": ["laravel", "ai", "tool", "citations", "validation"],
+    "license": "MIT",
+    "require": {
+        "php": "^8.4.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "laravel/ai": "^0.7|^0.10"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Citations\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Citations\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/Citations/src/CitationValidator.php
+++ b/src/Citations/src/CitationValidator.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Citations;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+#[Strict]
+class CitationValidator implements Tool
+{
+    public function description(): string
+    {
+        return <<<'TXT'
+            Validate citation tokens in Markdown against a declared citation list
+            and an allow-list of available sources. Returns coverage, unknown or
+            undeclared tokens, duplicates, and shape warnings as JSON.
+            TXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'body_markdown' => $schema
+                ->string()
+                ->description('Markdown body that may contain citation tokens like [type:id]')
+                ->required(),
+            'citations' => $schema
+                ->array()
+                ->description('Declared citations. Each item should include type, id, and optional role.')
+                ->required(),
+            'sources' => $schema
+                ->array()
+                ->description('Available sources. Each item should include entity_type (or type) and entity_id (or id).')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $bodyMarkdown = (string) $request->string('body_markdown');
+        $citations = $request->array('citations');
+        $sources = $request->array('sources');
+
+        $entityTypes = $this->allowedEntityTypes();
+        $roles = $this->allowedRoles();
+        $pattern = $this->tokenPattern($entityTypes);
+
+        preg_match_all($pattern, $bodyMarkdown, $matches, PREG_SET_ORDER);
+
+        $referenced = [];
+
+        foreach ($matches as $match) {
+            if (! isset($match[1], $match[2])) {
+                continue;
+            }
+
+            $type = $this->asString($match[1]);
+            $id = $this->asString($match[2]);
+
+            if ($type === '') {
+                continue;
+            }
+
+            if ($id === '') {
+                continue;
+            }
+
+            $referenced[] = $this->formatToken($type, $id);
+        }
+
+        $referenced = array_values(array_unique($referenced));
+        $available = [];
+
+        foreach ($sources as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            $type = $this->asString($source['entity_type'] ?? $source['type'] ?? null);
+            $id = $this->asString($source['entity_id'] ?? $source['id'] ?? null);
+
+            if ($type === '') {
+                continue;
+            }
+
+            if ($id === '') {
+                continue;
+            }
+
+            $available[] = $this->formatToken($type, $id);
+        }
+
+        $available = array_values(array_unique($available));
+        $declared = [];
+        $duplicates = [];
+        $warnings = [];
+
+        foreach ($citations as $citation) {
+            if (! is_array($citation)) {
+                $warnings[] = 'citation_not_object';
+
+                continue;
+            }
+
+            $type = $this->asString($citation['type'] ?? null);
+            $id = trim($this->asString($citation['id'] ?? null));
+            $role = $this->asString($citation['role'] ?? null);
+
+            if (! in_array($type, $entityTypes, true) || $id === '') {
+                $warnings[] = 'citation_shape_invalid';
+
+                continue;
+            }
+
+            if ($roles !== [] && ! in_array($role, $roles, true)) {
+                $warnings[] = 'citation_role_invalid';
+            }
+
+            $token = $this->formatToken($type, $id);
+
+            if (in_array($token, $declared, true)) {
+                $duplicates[] = $token;
+            }
+
+            $declared[] = $token;
+        }
+
+        $unknownReferenced = array_values(array_diff($referenced, $available));
+        $undeclaredReferenced = array_values(array_diff($referenced, $declared));
+        $coverage = $referenced === []
+            ? ($declared === [] ? 1.0 : 0.0)
+            : count(array_intersect($referenced, $available)) / count($referenced);
+
+        $payload = [
+            'valid' => $unknownReferenced === []
+                && $undeclaredReferenced === []
+                && $duplicates === []
+                && $warnings === [],
+            'coverage' => $coverage,
+            'referenced_tokens' => $referenced,
+            'declared_tokens' => array_values(array_unique($declared)),
+            'unknown_referenced_tokens' => $unknownReferenced,
+            'undeclared_referenced_tokens' => $undeclaredReferenced,
+            'duplicate_declared_tokens' => array_values(array_unique($duplicates)),
+            'warnings' => array_values(array_unique($warnings)),
+        ];
+
+        return json_encode(
+            $payload,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedEntityTypes(): array
+    {
+        $types = config('ai.toolkit.citations.entity_types', ['tag', 'category', 'performer']);
+
+        if (! is_array($types)) {
+            return ['tag', 'category', 'performer'];
+        }
+
+        $normalized = [];
+
+        foreach ($types as $type) {
+            $value = $this->asString($type);
+
+            if ($value !== '') {
+                $normalized[] = $value;
+            }
+        }
+
+        return $normalized === [] ? ['tag', 'category', 'performer'] : $normalized;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedRoles(): array
+    {
+        $roles = config('ai.toolkit.citations.roles', ['primary', 'supporting', 'mention']);
+
+        if (! is_array($roles)) {
+            return ['primary', 'supporting', 'mention'];
+        }
+
+        $normalized = [];
+
+        foreach ($roles as $role) {
+            $value = $this->asString($role);
+
+            if ($value !== '') {
+                $normalized[] = $value;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  list<string>  $entityTypes
+     */
+    private function tokenPattern(array $entityTypes): string
+    {
+        $configured = config('ai.toolkit.citations.token_pattern');
+
+        if (is_string($configured) && $configured !== '') {
+            return $configured;
+        }
+
+        $types = implode('|', array_map(
+            fn (string $type): string => preg_quote($type, '/'),
+            $entityTypes,
+        ));
+
+        return '/\[('.$types.'):([1-9][0-9]*)\]/';
+    }
+
+    private function formatToken(string $type, string $id): string
+    {
+        return sprintf('%s:%s', $type, $id);
+    }
+
+    private function asString(mixed $value): string
+    {
+        return match (true) {
+            is_string($value) => $value,
+            is_int($value), is_float($value) => (string) $value,
+            default => '',
+        };
+    }
+}

--- a/src/Citations/src/Citations.php
+++ b/src/Citations/src/Citations.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Citations;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+
+class Citations
+{
+    /**
+     * @return Collection<int, Tool>
+     */
+    public static function all(): Collection
+    {
+        return new Collection([
+            new CitationValidator,
+        ]);
+    }
+}

--- a/src/Citations/tests/CitationValidatorTest.php
+++ b/src/Citations/tests/CitationValidatorTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Citations\CitationValidator;
+
+it('has a description', function (): void {
+    expect((new CitationValidator)->description())->toContain('Validate citation tokens');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new CitationValidator))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new CitationValidator)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('body_markdown')
+        ->and($schema)->toHaveKey('citations')
+        ->and($schema)->toHaveKey('sources');
+});
+
+it('validates a clean citation set', function (): void {
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'See [tag:1] and [category:2].',
+        'citations' => [
+            ['type' => 'tag', 'id' => '1', 'role' => 'primary'],
+            ['type' => 'category', 'id' => '2', 'role' => 'supporting'],
+        ],
+        'sources' => [
+            ['entity_type' => 'tag', 'entity_id' => 1],
+            ['type' => 'category', 'id' => 2],
+        ],
+    ])), true);
+
+    expect($result['valid'])->toBeTrue()
+        ->and($result['coverage'])->toEqual(1.0)
+        ->and($result['referenced_tokens'])->toEqualCanonicalizing(['tag:1', 'category:2'])
+        ->and($result['warnings'])->toBeEmpty();
+});
+
+it('flags unknown undeclared duplicate and shape issues', function (): void {
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'See [tag:1] [tag:9] [tag:1].',
+        'citations' => [
+            ['type' => 'tag', 'id' => '1', 'role' => 'primary'],
+            ['type' => 'tag', 'id' => '1', 'role' => 'supporting'],
+            'not-an-object',
+            ['type' => 'unknown', 'id' => '3', 'role' => 'primary'],
+            ['type' => 'tag', 'id' => '', 'role' => 'primary'],
+            ['type' => 'tag', 'id' => '4', 'role' => 'invalid-role'],
+        ],
+        'sources' => [
+            ['entity_type' => 'tag', 'entity_id' => 1],
+            'skip-me',
+        ],
+    ])), true);
+
+    expect($result['valid'])->toBeFalse()
+        ->and($result['unknown_referenced_tokens'])->toContain('tag:9')
+        ->and($result['undeclared_referenced_tokens'])->toContain('tag:9')
+        ->and($result['duplicate_declared_tokens'])->toContain('tag:1')
+        ->and($result['warnings'])->toContain('citation_not_object')
+        ->and($result['warnings'])->toContain('citation_shape_invalid')
+        ->and($result['warnings'])->toContain('citation_role_invalid');
+});
+
+it('returns full coverage when nothing is referenced or declared', function (): void {
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'No citations here.',
+        'citations' => [],
+        'sources' => [],
+    ])), true);
+
+    expect($result['valid'])->toBeTrue()
+        ->and($result['coverage'])->toEqual(1.0);
+});
+
+it('returns zero coverage when citations are declared without references', function (): void {
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'No citations here.',
+        'citations' => [
+            ['type' => 'tag', 'id' => '1', 'role' => 'primary'],
+        ],
+        'sources' => [
+            ['entity_type' => 'tag', 'entity_id' => 1],
+        ],
+    ])), true);
+
+    expect($result['coverage'])->toEqual(0.0);
+});
+
+it('uses configured entity types roles and token pattern', function (): void {
+    config()->set('ai.toolkit.citations.entity_types', ['video']);
+    config()->set('ai.toolkit.citations.roles', ['source']);
+    config()->set('ai.toolkit.citations.token_pattern', '/\{(video):([1-9][0-9]*)\}/');
+
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'See {video:7} and [tag:1].',
+        'citations' => [
+            ['type' => 'video', 'id' => '7', 'role' => 'source'],
+        ],
+        'sources' => [
+            ['entity_type' => 'video', 'entity_id' => 7],
+        ],
+    ])), true);
+
+    expect($result['valid'])->toBeTrue()
+        ->and($result['referenced_tokens'])->toBe(['video:7']);
+});
+
+it('falls back when configured entity types or roles are invalid', function (): void {
+    config()->set('ai.toolkit.citations.entity_types', 'not-an-array');
+    config()->set('ai.toolkit.citations.roles', 'not-an-array');
+    config()->set('ai.toolkit.citations.token_pattern', '');
+
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'See [performer:3].',
+        'citations' => [
+            ['type' => 'performer', 'id' => '3', 'role' => 'mention'],
+        ],
+        'sources' => [
+            ['entity_type' => 'performer', 'entity_id' => 3],
+        ],
+    ])), true);
+
+    expect($result['valid'])->toBeTrue()
+        ->and($result['referenced_tokens'])->toBe(['performer:3']);
+});
+
+it('filters empty configured entity types and roles', function (): void {
+    config()->set('ai.toolkit.citations.entity_types', ['tag', '', null]);
+    config()->set('ai.toolkit.citations.roles', ['primary', '']);
+
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'See [tag:1].',
+        'citations' => [
+            ['type' => 'tag', 'id' => '1', 'role' => 'primary'],
+        ],
+        'sources' => [
+            ['entity_type' => 'tag', 'entity_id' => 1],
+        ],
+    ])), true);
+
+    expect($result['valid'])->toBeTrue();
+});
+
+it('falls back when configured entity types are empty', function (): void {
+    config()->set('ai.toolkit.citations.entity_types', []);
+    config()->set('ai.toolkit.citations.roles', []);
+
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'See [tag:1].',
+        'citations' => [
+            ['type' => 'tag', 'id' => '1', 'role' => 'anything'],
+        ],
+        'sources' => [
+            ['entity_type' => 'tag', 'entity_id' => 1],
+        ],
+    ])), true);
+
+    expect($result['valid'])->toBeTrue()
+        ->and($result['warnings'])->toBeEmpty();
+});
+
+it('ignores malformed token matches and empty source identities', function (): void {
+    config()->set('ai.toolkit.citations.token_pattern', '/(?:\[([a-z]*):([0-9]*)\]|\[skip\])/');
+
+    $result = json_decode((new CitationValidator)->handle(new Request([
+        'body_markdown' => 'See [tag:] [:1] [tag:2] [skip].',
+        'citations' => [
+            ['type' => 'tag', 'id' => '2', 'role' => 'primary'],
+        ],
+        'sources' => [
+            ['entity_type' => '', 'entity_id' => 1],
+            ['entity_type' => 'tag', 'entity_id' => ''],
+            ['entity_type' => 'tag', 'entity_id' => 2],
+            ['entity_type' => true, 'entity_id' => false],
+        ],
+    ])), true);
+
+    expect($result['referenced_tokens'])->toBe(['tag:2'])
+        ->and($result['valid'])->toBeTrue();
+});

--- a/src/Citations/tests/CitationsTest.php
+++ b/src/Citations/tests/CitationsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Shipfastlabs\Toolkit\Citations\Citations;
+use Shipfastlabs\Toolkit\Citations\CitationValidator;
+
+it('creates a collection of all Citations tools', function (): void {
+    $tools = Citations::all();
+
+    expect($tools)->toBeInstanceOf(Collection::class)
+        ->and($tools)->toHaveCount(1)
+        ->and($tools->all())->toContainOnlyInstancesOf(Tool::class);
+});
+
+it('includes each Citations tool exactly once', function (): void {
+    $classes = Citations::all()->map(fn ($tool): string => $tool::class);
+
+    expect($classes->all())->toEqualCanonicalizing([
+        CitationValidator::class,
+    ]);
+});

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exa/composer.json
+++ b/src/Exa/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/JigsawStack/composer.json
+++ b/src/JigsawStack/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Perplexity/composer.json
+++ b/src/Perplexity/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Scout/README.md
+++ b/src/Scout/README.md
@@ -1,0 +1,91 @@
+# shipfastlabs/toolkit-scout
+
+[![Latest Version](https://img.shields.io/packagist/v/shipfastlabs/toolkit-scout.svg)](https://packagist.org/packages/shipfastlabs/toolkit-scout)
+[![Total Downloads](https://img.shields.io/packagist/dt/shipfastlabs/toolkit-scout.svg)](https://packagist.org/packages/shipfastlabs/toolkit-scout)
+
+> Laravel Scout search tools for the Laravel AI SDK
+
+Part of the [shipfastlabs/toolkit](https://github.com/shipfastlabs/toolkit) catalog of reusable AI tools for the Laravel AI SDK.
+
+<!-- AUTO-GENERATED: do not edit above this line. Run `tools/docgen.sh`. -->
+
+
+## Installation
+
+```bash
+composer require shipfastlabs/toolkit-scout
+```
+
+This package depends on `laravel/scout`. Configure Scout as usual in your application.
+
+## Usage
+
+Register every Scout tool at once with the `Scout` helper:
+
+```php
+use Shipfastlabs\Toolkit\Scout\Scout;
+
+$tools = Scout::all(); // Collection<int, Tool>
+```
+
+Or add individual tools to an agent's `tools()`:
+
+```php
+use Shipfastlabs\Toolkit\Scout\ScoutSearch;
+
+$tools = [
+    new ScoutSearch,
+];
+```
+
+## Tools
+
+### ScoutSearch
+
+Search allow-listed Eloquent models with Laravel Scout.
+
+| Parameter | Type    | Required | Description                                                         |
+|-----------|---------|----------|---------------------------------------------------------------------|
+| `model`   | string  | yes      | Configured model alias under `ai.toolkit.scout.models`.             |
+| `query`   | string  | yes      | The Scout search query.                                             |
+| `limit`   | integer | no       | Maximum number of results to return (1-25). Defaults to 5.          |
+
+## Configuration
+
+Tools do not ship config files. Add model allow-lists and defaults to `config/ai.php`:
+
+```php
+'toolkit' => [
+    'scout' => [
+        'search' => [
+            'limit' => (int) env('SCOUT_TOOL_LIMIT', 5),
+        ],
+        'models' => [
+            // Short form:
+            'posts' => App\Models\Post::class,
+
+            // Or with display columns:
+            'posts' => [
+                'class' => App\Models\Post::class,
+                'columns' => ['name', 'slug'],
+            ],
+        ],
+    ],
+],
+```
+
+| Config key | Default | Description |
+|---|---|---|
+| `ai.toolkit.scout.models` | `[]` | Allow-listed model aliases and optional display columns. |
+| `ai.toolkit.scout.search.limit` | `5` | Default result limit (1-25). |
+
+## Safety
+
+- Only allow-listed model aliases can be searched.
+- Result counts are clamped to 1-25.
+- Non-searchable or missing model classes return friendly error strings.
+- Scout exceptions are caught and returned as strings so the model can recover.
+
+## Note for maintainers
+
+This package intentionally depends on `laravel/scout` in addition to `laravel/ai`. Please confirm that extra dependency is acceptable for the catalog before releasing.

--- a/src/Scout/composer.json
+++ b/src/Scout/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "shipfastlabs/toolkit-scout",
+    "description": "Laravel Scout search tools for the Laravel AI SDK",
+    "keywords": ["laravel", "ai", "tool", "scout", "search"],
+    "license": "MIT",
+    "require": {
+        "php": "^8.4.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "laravel/ai": "^0.7|^0.10",
+        "laravel/scout": "^10.0|^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Scout\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shipfastlabs\\Toolkit\\Scout\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/Scout/src/Scout.php
+++ b/src/Scout/src/Scout.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+
+class Scout
+{
+    /**
+     * @return Collection<int, Tool>
+     */
+    public static function all(): Collection
+    {
+        return new Collection([
+            new ScoutSearch,
+        ]);
+    }
+}

--- a/src/Scout/src/ScoutSearch.php
+++ b/src/Scout/src/ScoutSearch.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Throwable;
+
+#[Strict]
+class ScoutSearch implements Tool
+{
+    public function description(): string
+    {
+        return <<<'TXT'
+            Search allow-listed Eloquent models with Laravel Scout.
+            Pass a configured model alias and a query; returns a bounded list of
+            matching records with their configured display columns.
+            TXT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'model' => $schema
+                ->string()
+                ->description('Configured model alias to search (see ai.toolkit.scout.models)')
+                ->required(),
+            'query' => $schema
+                ->string()
+                ->description('The Scout search query')
+                ->required(),
+            'limit' => $schema
+                ->integer()
+                ->description('Maximum number of results to return (1-25, default: 5)')
+                ->nullable()
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $modelAlias = trim((string) $request->string('model'));
+        $query = $request->string('query')->trim();
+
+        if ($modelAlias === '') {
+            return 'The model alias is empty. Provide a configured model alias to search.';
+        }
+
+        if ($query->isEmpty()) {
+            return 'The search query is empty. Provide a query to search for.';
+        }
+
+        $modelConfig = $this->resolveModelConfig($modelAlias);
+
+        if ($modelConfig === null) {
+            return sprintf(
+                'The model alias [%s] is not allow-listed. Configure it under ai.toolkit.scout.models.',
+                $modelAlias
+            );
+        }
+
+        $class = $modelConfig['class'];
+
+        if ($class === '' || ! class_exists($class)) {
+            return sprintf('The model class for alias [%s] could not be resolved.', $modelAlias);
+        }
+
+        if (! is_subclass_of($class, Model::class)) {
+            return sprintf('The model class for alias [%s] must extend Eloquent Model.', $modelAlias);
+        }
+
+        if (! method_exists($class, 'search')) {
+            return sprintf('The model class for alias [%s] is not searchable with Laravel Scout.', $modelAlias);
+        }
+
+        $limit = $request->filled('limit')
+            ? $request->integer('limit')
+            : $this->defaultLimit();
+
+        $limit = max(1, min(25, $limit));
+
+        $columns = $modelConfig['columns'];
+
+        try {
+            $builder = $class::search((string) $query);
+
+            if (! is_object($builder) || ! method_exists($builder, 'take')) {
+                return sprintf('The Scout search builder for alias [%s] is invalid.', $modelAlias);
+            }
+
+            $limited = $builder->take($limit);
+
+            if (! is_object($limited) || ! method_exists($limited, 'get')) {
+                return sprintf('The Scout search builder for alias [%s] is invalid.', $modelAlias);
+            }
+
+            $results = $limited->get();
+        } catch (Throwable $throwable) {
+            return sprintf('The Scout search request failed: %s', $throwable->getMessage());
+        }
+
+        if (! $results instanceof Collection) {
+            return sprintf('The Scout search response for alias [%s] was invalid.', $modelAlias);
+        }
+
+        $mapped = [];
+
+        foreach ($results as $entity) {
+            if (! $entity instanceof Model) {
+                continue;
+            }
+
+            $row = [
+                'model' => $modelAlias,
+                'id' => $entity->getKey(),
+            ];
+
+            foreach ($columns as $column) {
+                $row[$column] = $entity->getAttribute($column);
+            }
+
+            $mapped[] = $row;
+        }
+
+        $payload = [
+            'model' => $modelAlias,
+            'query' => (string) $query,
+            'results' => $mapped,
+        ];
+
+        return json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array{class: string, columns: list<string>}|null
+     */
+    private function resolveModelConfig(string $alias): ?array
+    {
+        $models = config('ai.toolkit.scout.models', []);
+
+        if (! is_array($models) || ! array_key_exists($alias, $models)) {
+            return null;
+        }
+
+        $config = $models[$alias];
+
+        if (is_string($config)) {
+            return [
+                'class' => $config,
+                'columns' => ['name'],
+            ];
+        }
+
+        if (! is_array($config) || ! array_key_exists('class', $config)) {
+            return null;
+        }
+
+        $class = $config['class'];
+
+        if (! is_string($class)) {
+            return null;
+        }
+
+        $columns = $config['columns'] ?? ['name'];
+
+        if (! is_array($columns)) {
+            $columns = ['name'];
+        }
+
+        $normalizedColumns = [];
+
+        foreach ($columns as $column) {
+            $value = $this->asString($column);
+
+            if ($value !== '') {
+                $normalizedColumns[] = $value;
+            }
+        }
+
+        if ($normalizedColumns === []) {
+            $normalizedColumns = ['name'];
+        }
+
+        return [
+            'class' => $class,
+            'columns' => $normalizedColumns,
+        ];
+    }
+
+    private function defaultLimit(): int
+    {
+        $limit = config('ai.toolkit.scout.search.limit', 5);
+
+        return is_numeric($limit) ? (int) $limit : 5;
+    }
+
+    private function asString(mixed $value): string
+    {
+        return match (true) {
+            is_string($value) => $value,
+            is_int($value), is_float($value) => (string) $value,
+            default => '',
+        };
+    }
+}

--- a/src/Scout/tests/Fixtures/BrokenSearchableModel.php
+++ b/src/Scout/tests/Fixtures/BrokenSearchableModel.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BrokenSearchableModel extends Model
+{
+    //
+}

--- a/src/Scout/tests/Fixtures/FakeSearchableModel.php
+++ b/src/Scout/tests/Fixtures/FakeSearchableModel.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class FakeSearchableModel extends Model
+{
+    public $incrementing = false;
+
+    protected $guarded = [];
+
+    /**
+     * @return object{take: callable(int): object, get: callable(): Collection<int, FakeSearchableModel>}
+     */
+    public static function search(string $query): object
+    {
+        $records = [
+            self::makeRecord(1, 'Laravel', 'laravel'),
+            self::makeRecord(2, 'Laravel AI', 'laravel-ai'),
+            self::makeRecord(3, 'Toolkit', 'toolkit'),
+        ];
+
+        return new class($records)
+        {
+            /**
+             * @param  list<FakeSearchableModel>  $records
+             */
+            public function __construct(private array $records) {}
+
+            public function take(int $limit): self
+            {
+                $this->records = array_slice($this->records, 0, $limit);
+
+                return $this;
+            }
+
+            /**
+             * @return Collection<int, FakeSearchableModel>
+             */
+            public function get(): Collection
+            {
+                return collect($this->records);
+            }
+        };
+    }
+
+    private static function makeRecord(int $id, string $name, string $slug): self
+    {
+        $model = new self;
+        $model->forceFill([
+            'id' => $id,
+            'name' => $name,
+            'slug' => $slug,
+        ]);
+        $model->exists = true;
+
+        return $model;
+    }
+}

--- a/src/Scout/tests/Fixtures/InvalidBuilderSearchableModel.php
+++ b/src/Scout/tests/Fixtures/InvalidBuilderSearchableModel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class InvalidBuilderSearchableModel extends Model
+{
+    public static function search(string $query): string
+    {
+        return 'not-a-builder';
+    }
+}

--- a/src/Scout/tests/Fixtures/MissingGetSearchableModel.php
+++ b/src/Scout/tests/Fixtures/MissingGetSearchableModel.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MissingGetSearchableModel extends Model
+{
+    public static function search(string $query): object
+    {
+        return new class
+        {
+            public function take(int $limit): string
+            {
+                return 'not-gettable';
+            }
+        };
+    }
+}

--- a/src/Scout/tests/Fixtures/MixedResultsSearchableModel.php
+++ b/src/Scout/tests/Fixtures/MixedResultsSearchableModel.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class MixedResultsSearchableModel extends Model
+{
+    public $incrementing = false;
+
+    protected $guarded = [];
+
+    public static function search(string $query): object
+    {
+        $model = new self;
+        $model->forceFill(['id' => 1, 'name' => 'Laravel']);
+        $model->exists = true;
+
+        return new readonly class([$model, 'skip-me'])
+        {
+            /**
+             * @param  list<mixed>  $records
+             */
+            public function __construct(private array $records) {}
+
+            public function take(int $limit): self
+            {
+                return $this;
+            }
+
+            /**
+             * @return Collection<int, mixed>
+             */
+            public function get(): Collection
+            {
+                return collect($this->records);
+            }
+        };
+    }
+}

--- a/src/Scout/tests/Fixtures/NonCollectionSearchableModel.php
+++ b/src/Scout/tests/Fixtures/NonCollectionSearchableModel.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonCollectionSearchableModel extends Model
+{
+    public static function search(string $query): object
+    {
+        return new class
+        {
+            public function take(int $limit): self
+            {
+                return $this;
+            }
+
+            public function get(): array
+            {
+                return [];
+            }
+        };
+    }
+}

--- a/src/Scout/tests/Fixtures/ThrowingSearchableModel.php
+++ b/src/Scout/tests/Fixtures/ThrowingSearchableModel.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Toolkit\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
+
+class ThrowingSearchableModel extends Model
+{
+    public static function search(string $query): object
+    {
+        return new class
+        {
+            public function take(int $limit): self
+            {
+                return $this;
+            }
+
+            public function get(): never
+            {
+                throw new RuntimeException('boom');
+            }
+        };
+    }
+}

--- a/src/Scout/tests/ScoutSearchTest.php
+++ b/src/Scout/tests/ScoutSearchTest.php
@@ -1,0 +1,366 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Tools\Request;
+use Shipfastlabs\Toolkit\Scout\ScoutSearch;
+use Shipfastlabs\Toolkit\Scout\Tests\Fixtures\BrokenSearchableModel;
+use Shipfastlabs\Toolkit\Scout\Tests\Fixtures\FakeSearchableModel;
+use Shipfastlabs\Toolkit\Scout\Tests\Fixtures\InvalidBuilderSearchableModel;
+use Shipfastlabs\Toolkit\Scout\Tests\Fixtures\MissingGetSearchableModel;
+use Shipfastlabs\Toolkit\Scout\Tests\Fixtures\MixedResultsSearchableModel;
+use Shipfastlabs\Toolkit\Scout\Tests\Fixtures\NonCollectionSearchableModel;
+use Shipfastlabs\Toolkit\Scout\Tests\Fixtures\ThrowingSearchableModel;
+
+it('has a description', function (): void {
+    expect((new ScoutSearch)->description())->toContain('Laravel Scout');
+});
+
+it('is marked as strict', function (): void {
+    expect(Strict::isAppliedTo(new ScoutSearch))->toBeTrue();
+});
+
+it('exposes its schema', function (): void {
+    $schema = (new ScoutSearch)->schema(new JsonSchemaTypeFactory);
+
+    expect($schema)->toHaveKey('model')
+        ->and($schema)->toHaveKey('query')
+        ->and($schema)->toHaveKey('limit');
+});
+
+it('returns an error when the model alias is empty', function (): void {
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => '   ',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('model alias is empty');
+});
+
+it('returns an error when the query is empty', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => FakeSearchableModel::class,
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => '   ',
+    ]));
+
+    expect($result)->toContain('search query is empty');
+});
+
+it('returns an error when the model alias is not allow-listed', function (): void {
+    config()->set('ai.toolkit.scout.models', []);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('not allow-listed');
+});
+
+it('returns an error when the model class cannot be resolved', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => 'App\\Missing\\Model',
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('could not be resolved');
+});
+
+it('returns an error when the model class is empty', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => [
+            'class' => '',
+            'columns' => ['name'],
+        ],
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('could not be resolved');
+});
+
+it('returns an error when the model class is not a string', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => [
+            'class' => 123,
+            'columns' => ['name'],
+        ],
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('not allow-listed');
+});
+
+it('returns an error when the configured class is not a model', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => stdClass::class,
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('must extend Eloquent Model');
+});
+
+it('returns an error when the model is not searchable', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => BrokenSearchableModel::class,
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('not searchable');
+});
+
+it('returns search results on success', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => [
+            'class' => FakeSearchableModel::class,
+            'columns' => ['name', 'slug'],
+        ],
+    ]);
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+        'limit' => 2,
+    ])), true);
+
+    expect($result['model'])->toBe('posts')
+        ->and($result['query'])->toBe('laravel')
+        ->and($result['results'])->toHaveCount(2)
+        ->and($result['results'][0])->toMatchArray([
+            'model' => 'posts',
+            'id' => 1,
+            'name' => 'Laravel',
+            'slug' => 'laravel',
+        ]);
+});
+
+it('accepts a string model class config and default columns', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => FakeSearchableModel::class,
+    ]);
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ])), true);
+
+    expect($result['results'][0])->toHaveKey('name')
+        ->and($result['results'][0])->not->toHaveKey('slug');
+});
+
+it('uses the configured default limit', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => FakeSearchableModel::class,
+    ]);
+    config()->set('ai.toolkit.scout.search.limit', 1);
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ])), true);
+
+    expect($result['results'])->toHaveCount(1);
+});
+
+it('clamps limit between 1 and 25', function (int $input, int $expected): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => FakeSearchableModel::class,
+    ]);
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+        'limit' => $input,
+    ])), true);
+
+    expect($result['results'])->toHaveCount(min($expected, 3));
+})->with([
+    'too low' => [-5, 1],
+    'zero' => [0, 1],
+    'minimum' => [1, 1],
+    'maximum' => [25, 25],
+    'too high' => [50, 25],
+]);
+
+it('falls back when configured limit is not numeric', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => FakeSearchableModel::class,
+    ]);
+    config()->set('ai.toolkit.scout.search.limit', 'nope');
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+        'limit' => null,
+    ])), true);
+
+    expect($result['results'])->toHaveCount(3);
+});
+
+it('returns an error when model config is malformed', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => ['columns' => ['name']],
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('not allow-listed');
+});
+
+it('falls back to name when columns are empty', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => [
+            'class' => FakeSearchableModel::class,
+            'columns' => [],
+        ],
+    ]);
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+        'limit' => 1,
+    ])), true);
+
+    expect($result['results'][0])->toHaveKey('name');
+});
+
+it('returns a friendly error when the search throws', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => ThrowingSearchableModel::class,
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('Scout search request failed')
+        ->and($result)->toContain('boom');
+});
+
+it('ignores non-array models config', function (): void {
+    config()->set('ai.toolkit.scout.models', 'invalid');
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('not allow-listed');
+});
+
+it('falls back to name when columns config is not an array', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => [
+            'class' => FakeSearchableModel::class,
+            'columns' => 'name',
+        ],
+    ]);
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+        'limit' => 1,
+    ])), true);
+
+    expect($result['results'][0])->toHaveKey('name');
+});
+
+it('returns an error when the search builder is invalid', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => InvalidBuilderSearchableModel::class,
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('search builder');
+});
+
+it('returns an error when the limited builder cannot get results', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => MissingGetSearchableModel::class,
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('search builder');
+});
+
+it('returns an error when the search response is not a collection', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => NonCollectionSearchableModel::class,
+    ]);
+
+    $result = (new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ]));
+
+    expect($result)->toContain('response');
+});
+
+it('skips non-model results from the search collection', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => MixedResultsSearchableModel::class,
+    ]);
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+    ])), true);
+
+    expect($result['results'])->toHaveCount(1)
+        ->and($result['results'][0]['name'])->toBe('Laravel');
+});
+
+it('stringifies numeric column names from config', function (): void {
+    config()->set('ai.toolkit.scout.models', [
+        'posts' => [
+            'class' => FakeSearchableModel::class,
+            'columns' => [1.5, 'name'],
+        ],
+    ]);
+
+    $result = json_decode((new ScoutSearch)->handle(new Request([
+        'model' => 'posts',
+        'query' => 'laravel',
+        'limit' => 1,
+    ])), true);
+
+    expect($result['results'][0])->toHaveKey('1.5')
+        ->and($result['results'][0])->toHaveKey('name');
+});

--- a/src/Scout/tests/ScoutTest.php
+++ b/src/Scout/tests/ScoutTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Shipfastlabs\Toolkit\Scout\Scout;
+use Shipfastlabs\Toolkit\Scout\ScoutSearch;
+
+it('creates a collection of all Scout tools', function (): void {
+    $tools = Scout::all();
+
+    expect($tools)->toBeInstanceOf(Collection::class)
+        ->and($tools)->toHaveCount(1)
+        ->and($tools->all())->toContainOnlyInstancesOf(Tool::class);
+});
+
+it('includes each Scout tool exactly once', function (): void {
+    $classes = Scout::all()->map(fn ($tool): string => $tool::class);
+
+    expect($classes->all())->toEqualCanonicalizing([
+        ScoutSearch::class,
+    ]);
+});

--- a/src/Tavily/composer.json
+++ b/src/Tavily/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.4.0",
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {

--- a/stub/composer.json
+++ b/stub/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/ai": "^0.7"
+        "laravel/ai": "^0.7|^0.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- New `src/Citations` package with `CitationValidator` + `Citations::all()`.
- New `src/Scout` package with `ScoutSearch` + `Scout::all()`.
- Both read config from `ai.toolkit.*` and ship no config files/providers.

## Citations
Generalized from an app-level article citation validator. Entity types, roles, and the token regex are configurable under `ai.toolkit.citations.*` instead of being hardcoded to catalog tag/category/performer shapes.

## Scout
Allow-listed Scout search over configured model aliases. **This package depends on `laravel/scout` in addition to `laravel/ai`.** Please confirm that extra dependency is acceptable for the catalog; if not, we can drop Scout and keep Citations only.

## Depends on
Please also merge #15 (`laravel/ai` constraint widen).

## Labels
Please apply `new-tool`.

## Test plan
- [x] `composer test` green (pint + rector + phpstan max + 100% type/code coverage)
- [x] 378 tests passing


Made with [Cursor](https://cursor.com)